### PR TITLE
Significantly shortens the Task list (tasks.json)

### DIFF
--- a/src/vscode.cpp
+++ b/src/vscode.cpp
@@ -378,6 +378,10 @@ bool CreateVsCodeTasks(CSrcFiles& cSrcFiles, ttCList* plstResults)
             cszMakeCommand.printf("nmake.exe -nologo clean release %s", (char*) cszMakeFileOption);
             AddMsvcTask(kfOut, "Rebuild Release MSVC", txtNormalGroup, cszMakeCommand);
 
+#if 0
+            // REVIEW: [KeyWorks - 8/4/2019] We certainly can add these, but they would be used rarely, if ever. The Ninja command
+            // is risky because if you change compilers, you might also need to change problem matchers
+
             // Ninja Debug Build
 
             AddMsvcTask(kfOut, "Ninja Debug Build", txtNormalGroup, cSrcFiles.GetBoolOption(OPT_64BIT) ?
@@ -397,11 +401,15 @@ bool CreateVsCodeTasks(CSrcFiles& cSrcFiles, ttCList* plstResults)
 
             cszMakeCommand.printf("nmake.exe -nologo deps %s", (char*) cszMakeFileOption);
             AddTask(kfOut, "View Dependencies", "test", cszMakeCommand, "");
+#endif
 
             // Test Generate messages.po
 
-            cszMakeCommand.printf("nmake.exe -nologo locale %s", (char*) cszMakeFileOption);
-            AddTask(kfOut, "Generate messages.pos", "test", cszMakeCommand, "");
+            if (FindFileEnv("PATH", "xgettext.exe"))
+            {
+                cszMakeCommand.printf("nmake.exe -nologo locale %s", (char*) cszMakeFileOption);
+                AddTask(kfOut, "Build messages.pos", "test", cszMakeCommand, "");
+            }
 
 #if defined(_WIN32)
             // If we're on Windows, then we also look to see if either the clang or gcc compiler is available. If so,


### PR DESCRIPTION
Fixes #139

### Description:
First and foremost, this significantly reduces the size of the Task list in VS Code. It was a nice idea to expose all the other things that Ninja and our makefile allow, they would be used so rarely that it just becomes clutter when they are added to the Terminal menu.

We added Ninja Debug Build and then removed it. So technically it's fixed. :+1: However, use of it was problematic. If you added it as the Pretask to Launch and then edited a file in one of the BuildLibs sources, the target would no longer be built correctly. If you changed compiles from msvc to clang-cl, you would no longer have a valid problem matcher (but you would if you use the compiler's Build task). All of which meant that we could add it, but there were few circumstances where anyone should be using it. It's now gone.

