### PR TITLE
Creates support for clang-cl as compiler name

### DIFF
--- a/src/cmplrMsvc.cpp
+++ b/src/cmplrMsvc.cpp
@@ -144,22 +144,6 @@ void CNinja::msvcWriteCompilerFlags(CMPLR_TYPE cmplr)
         m_pkfOut->WriteStr(m_gentype == GEN_DEBUG64 || m_gentype == GEN_RELEASE64 ? " -m64" : " -m32"); // specify the platform
         if (m_gentype == GEN_RELEASE32 || m_gentype == GEN_RELEASE64)
             m_pkfOut->WriteStr(" -flto -fwhole-program-vtables");   // whole program optimization
-
-        if (GetOption(OPT_CLANG_CMN))
-        {
-            m_pkfOut->WriteChar(' ');
-            m_pkfOut->WriteStr(GetOption(OPT_CLANG_CMN));
-        }
-        if (GetOption(OPT_CLANG_REL) && (m_gentype == GEN_RELEASE32 || m_gentype == GEN_RELEASE64))
-        {
-            m_pkfOut->WriteChar(' ');
-            m_pkfOut->WriteStr(GetOption(OPT_CLANG_REL));
-        }
-        if (GetOption(OPT_CLANG_DBG) && (m_gentype == GEN_DEBUG32 || m_gentype == GEN_DEBUG64))
-        {
-            m_pkfOut->WriteChar(' ');
-            m_pkfOut->WriteStr(GetOption(OPT_CLANG_DBG));
-        }
     }
 
     if (GetPchHeader())
@@ -207,7 +191,7 @@ void CNinja::msvcWriteCompilerDirectives(CMPLR_TYPE cmplr)
                     );
         }
     }
-    else
+    else    ////// clang-cl compiler //////////////
     {
         if (GetPchHeader())
         {
@@ -375,7 +359,7 @@ void CNinja::msvcWriteRcDirective(CMPLR_TYPE cmplr)
 {
     if (ttFileExists(GetRcFile()))
     {
-        if (cmplr == CMPLR_CLANG && !GetBoolOption(OPT_MS_RC))
+        if (cmplr == CMPLR_CLANG_CL && !GetBoolOption(OPT_MS_RC))
             m_pkfOut->WriteStr("rule rc\n  command = llvm-rc.exe -nologo");
         else
             m_pkfOut->WriteStr("rule rc\n  command = rc.exe -nologo");

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -368,11 +368,11 @@ int main(int argc, char* argv[])
                 countNinjas++;
             if (cNinja.CreateBuildFile(CNinja::GEN_RELEASE64, CNinja::CMPLR_MSVC))
                 countNinjas++;
+            if (cNinja.CreateBuildFile(CNinja::GEN_DEBUG64, CNinja::CMPLR_CLANG_CL))
+                countNinjas++;
+            if (cNinja.CreateBuildFile(CNinja::GEN_RELEASE64, CNinja::CMPLR_CLANG_CL))
+                countNinjas++;
 #endif
-            if (cNinja.CreateBuildFile(CNinja::GEN_DEBUG64, CNinja::CMPLR_CLANG))
-                countNinjas++;
-            if (cNinja.CreateBuildFile(CNinja::GEN_RELEASE64, CNinja::CMPLR_CLANG))
-                countNinjas++;
         }
         if (cNinja.GetBoolOption(OPT_32BIT))
         {
@@ -381,11 +381,11 @@ int main(int argc, char* argv[])
                 countNinjas++;
             if (cNinja.CreateBuildFile(CNinja::GEN_RELEASE32, CNinja::CMPLR_MSVC))
                 countNinjas++;
+            if (cNinja.CreateBuildFile(CNinja::GEN_DEBUG32, CNinja::CMPLR_CLANG_CL))
+                countNinjas++;
+            if (cNinja.CreateBuildFile(CNinja::GEN_RELEASE32, CNinja::CMPLR_CLANG_CL))
+                countNinjas++;
 #endif
-            if (cNinja.CreateBuildFile(CNinja::GEN_DEBUG32, CNinja::CMPLR_CLANG))
-                countNinjas++;
-            if (cNinja.CreateBuildFile(CNinja::GEN_RELEASE32, CNinja::CMPLR_CLANG))
-                countNinjas++;
         }
 
         if (ttIsNonEmpty(cNinja.GetHHPName()))
@@ -432,12 +432,12 @@ void MakeFileCaller(UPDATE_TYPE upType, const char* pszRootDir)
                 break;
 
             case UPDATE_CLANG_CL64:
-                if (cNinja.CreateBuildFile(CNinja::GEN_RELEASE64, CNinja::CMPLR_CLANG))
+                if (cNinja.CreateBuildFile(CNinja::GEN_RELEASE64, CNinja::CMPLR_CLANG_CL))
                     printf(GETSTRING(IDS_FILE_UPDATED), cNinja.GetScriptFile());
                 break;
 
             case UPDATE_CLANG_CL32:
-                if (cNinja.CreateBuildFile(CNinja::GEN_RELEASE32, CNinja::CMPLR_CLANG))
+                if (cNinja.CreateBuildFile(CNinja::GEN_RELEASE32, CNinja::CMPLR_CLANG_CL))
                     printf(GETSTRING(IDS_FILE_UPDATED), cNinja.GetScriptFile());
                 break;
 
@@ -452,12 +452,12 @@ void MakeFileCaller(UPDATE_TYPE upType, const char* pszRootDir)
                 break;
 
             case UPDATE_CLANG_CL64D:
-                if (cNinja.CreateBuildFile(CNinja::GEN_DEBUG64, CNinja::CMPLR_CLANG))
+                if (cNinja.CreateBuildFile(CNinja::GEN_DEBUG64, CNinja::CMPLR_CLANG_CL))
                     printf(GETSTRING(IDS_FILE_UPDATED), cNinja.GetScriptFile());
                 break;
 
             case UPDATE_CLANG_CL32D:
-                if (cNinja.CreateBuildFile(CNinja::GEN_DEBUG32, CNinja::CMPLR_CLANG))
+                if (cNinja.CreateBuildFile(CNinja::GEN_DEBUG32, CNinja::CMPLR_CLANG_CL))
                     printf(GETSTRING(IDS_FILE_UPDATED), cNinja.GetScriptFile());
                 break;
 

--- a/src/ninja.cpp
+++ b/src/ninja.cpp
@@ -266,7 +266,7 @@ bool CNinja::CreateBuildFile(GEN_TYPE gentype, CMPLR_TYPE cmplr)
         }
     }
 
-    if (cmplr == CMPLR_MSVC || cmplr == CMPLR_CLANG)
+    if (cmplr == CMPLR_MSVC || cmplr == CMPLR_CLANG_CL)
     {
         msvcWriteCompilerComments(cmplr);
         msvcWriteCompilerFlags(cmplr);
@@ -368,7 +368,7 @@ bool CNinja::CreateBuildFile(GEN_TYPE gentype, CMPLR_TYPE cmplr)
 
     // Write the final build rules to complete the project
 
-    if (cmplr == CMPLR_MSVC || cmplr == CMPLR_CLANG)
+    if (cmplr == CMPLR_MSVC || cmplr == CMPLR_CLANG_CL)
     {
         msvcWriteMidlTargets(cmplr);
         msvcWriteLinkTargets(cmplr);


### PR DESCRIPTION
Fixes #115

### Description:

This changes most references to the clang compiler into a clang-cl compiler. I didn't actually make it internal, since it is still potentially useful under some circumstances.

The one thing that is no longer supported are specific flags for the clang-cl compiler. The **CLANG_** flags are now exclusively for the clang/gcc compilers. The regular CFlags are passed to clang-cl.exe just as they are to cl.exe.

