### PR TITLE
Add support for DebugFiles: section

### DIFF
--- a/src/csrcfiles.h
+++ b/src/csrcfiles.h
@@ -110,8 +110,6 @@ public:
     ttlib::cstr& AddFile(std::string_view filename) { return m_lstSrcFiles.addfilename(filename); }
     void AddSourcePattern(std::string_view FilePattern);
 
-    // These are just for convenience--it's fine to call getOptValue directly
-
     const ttlib::cstr& GetProjectName() { return m_Options[OPT::PROJECT].value; }
     const ttlib::cstr& GetPchCpp();
 
@@ -166,11 +164,10 @@ public:
     }
 
 protected:
-    // Protected functions
-
     void ParseOption(std::string_view yamlLine);
 
     void ProcessFile(std::string_view line);
+    void ProcessDebugFile(std::string_view line);
     void ProcessOption(std::string_view line);
 
     void ProcessIncludeDirective(std::string_view file, ttlib::cstr root = std::string {});
@@ -184,9 +181,10 @@ protected:
     ttlib::cstr m_RCname;   // Resource file to build (if any)
     ttlib::cstr m_HPPname;  // HTML Help project file
 
-    ttlib::cstrVector m_lstSrcFiles;  // List of all source files
-    ttlib::cstrVector m_lstLibFiles;  // List of any files used to build additional library
-    ttlib::cstrVector m_lstIdlFiles;  // List of any idl files to compile with midl compiler
+    ttlib::cstrVector m_lstSrcFiles;    // List of all source files except DEBUG build files
+    ttlib::cstrVector m_lstLibFiles;    // List of any files used to build additional library
+    ttlib::cstrVector m_lstIdlFiles;    // List of any idl files to compile with midl compiler
+    ttlib::cstrVector m_lstDebugFiles;  // List of all source files for DEBUG builds only
 
     ttlib::cstrVector m_lstIncludeSrcFiles;
 
@@ -196,8 +194,6 @@ protected:
 
 private:
     friend CWriteSrcFiles;
-
-    // Class members
 
     ttlib::cstrVector m_lstErrMessages;  // List of any errors that occurred during processing
 
@@ -211,6 +207,15 @@ private:
     ttlib::cstr m_dbgTarget;
 
     std::string m_strTargetDir;
+
+    enum SRC_SECTION : size_t
+    {
+        SECTION_UNKNOWN,
+        SECTION_OPTIONS,
+        SECTION_FILES,
+        SECTION_DEBUG_FILES,
+    };
+    SRC_SECTION m_section { SECTION_UNKNOWN };
 
     int m_RequiredMajor { 1 };  // These three get filled in to the minimum ttBld version required to process.
     int m_RequiredMinor { 4 };

--- a/src/precompile/pch.h
+++ b/src/precompile/pch.h
@@ -81,6 +81,6 @@ namespace fs = std::filesystem;
 
 #include "strings.h"
 
-constexpr const auto txtVersion = "ttBld 1.6.0";
+constexpr const auto txtVersion = "ttBld 1.7.0";
 constexpr const auto txtCopyRight = "Copyright (c) 2002-2020 KeyWorks Software";
 constexpr const auto txtAppname = "ttBld";

--- a/src/winsrc/ttBld.rc
+++ b/src/winsrc/ttBld.rc
@@ -88,14 +88,14 @@ BEGIN
             VALUE "Comments", "Released under Apache License\0"
             VALUE "CompanyName", "KeyWorks Software\0"
             VALUE "FileDescription", "Ninja Build Script generator\0"
-            VALUE "FileVersion", "1.6.0.8295\0"
+            VALUE "FileVersion", "1.7.0.0\0"
             VALUE "InternalName", "ttBld\0"
             VALUE "LegalCopyright", "Copyright (c) 2002-2020 KeyWorks Software\0"
             VALUE "LegalTrademarks", "\0"
             VALUE "OriginalFilename", "ttBld.exe\0"
             VALUE "PrivateBuild", "\0"
             VALUE "ProductName", "ttBld\0"
-            VALUE "ProductVersion", "1.6\0"
+            VALUE "ProductVersion", "1.7\0"
             VALUE "SpecialBuild", "\0"
         END
     END


### PR DESCRIPTION
Fixes #256

### Description:
This PR adds support for a `DebugFiles:` section.

Version number increased to 1.7 since any caller using `DebugFiles:` must use this version or later to be able to create a debug build.

Note that `DebugFiles:` does not support .include, .idl, .rc, of .hhp files. It does support wildcards.

