### PR TITLE
Output results to debugger

### DIFF
--- a/src/winsrc/mainapp.cpp
+++ b/src/winsrc/mainapp.cpp
@@ -351,6 +351,9 @@ int main(int /* argc */, char** /* argv */)
         for (auto iter: cNinja.getErrorMsgs())
         {
             std::cout << iter << '\n';
+#if defined(_DEBUG)
+            OutputDebugStringW(iter.to_utf16().c_str());
+#endif  // _DEBUG
         }
         std::cout << "\n\n";
     }
@@ -358,10 +361,18 @@ int main(int /* argc */, char** /* argv */)
     if (countNinjas > 0)
     {
         std::cout << _tt(strIdCreated) << countNinjas << " .ninja" << _tt(strIdFiles) << '\n';
+#if defined(_DEBUG)
+        ttlib::cstr msg(_ttc(strIdCreated) << countNinjas << " .ninja" << _tt(strIdFiles));
+        OutputDebugStringW(msg.to_utf16().c_str());
+#endif  // _DEBUG
     }
     else
-        std::cout << _tt(strIdAllNinjaCurrent) << '\n';
-
+    {
+        std::cout << _ttc(strIdAllNinjaCurrent) << '\n';
+#if defined(_DEBUG)
+        OutputDebugStringW(_ttc(strIdAllNinjaCurrent).to_utf16().c_str());
+#endif  // _DEBUG
+    }
     return 0;
 }
 


### PR DESCRIPTION
<!-- List the issue (or issues) this branch will fix -->
Fixes #

### Description:
When running under a debugger, it can be useful to see the output messages without having to require creating a console window and breaking just prior to exiting while the console window still exists. This PR sends the final messages to `OutputDebugStringW()` when running the debug Windows version.

Note that a **wxWidgets** version should use `wxLogDebug()` to provide a cross-platform version.

