### PR TITLE
Generate correct tasks.json and bld/makefile

### DIFF
--- a/src/createmakefile.cpp
+++ b/src/createmakefile.cpp
@@ -146,9 +146,20 @@ bool CNinja::CreateMakeFile(MAKE_TYPE type)
     }
     else
     {
+        ttlib::cstr path(MakeFile);
+        path.remove_filename();
+        if (!path.dirExists())
+        {
+            if (!fs::create_directory(path.wx_str()))
+            {
+                std::cout << _tt(strIdCantWrite) << MakeFile << '\n';
+                return false;
+            }
+        }
+
         if (file.WriteFile(MakeFile))
         {
-            std::cout << MakeFile << _tt(strIdUpdated) << '\n';
+            std::cout << _tt(strIdCreated) << MakeFile << '\n';
             return true;
         }
         else

--- a/src/winsrc/mainapp.cpp
+++ b/src/winsrc/mainapp.cpp
@@ -362,7 +362,7 @@ int main(int /* argc */, char** /* argv */)
     {
         std::cout << _tt(strIdCreated) << countNinjas << " .ninja" << _tt(strIdFiles) << '\n';
 #if defined(_DEBUG)
-        ttlib::cstr msg(_ttc(strIdCreated) << countNinjas << " .ninja" << _tt(strIdFiles));
+        ttlib::cstr msg(_ttc(strIdCreated) << countNinjas << " .ninja" << _tt(strIdFiles) << '\n');
         OutputDebugStringW(msg.to_utf16().c_str());
 #endif  // _DEBUG
     }
@@ -370,7 +370,7 @@ int main(int /* argc */, char** /* argv */)
     {
         std::cout << _ttc(strIdAllNinjaCurrent) << '\n';
 #if defined(_DEBUG)
-        OutputDebugStringW(_ttc(strIdAllNinjaCurrent).to_utf16().c_str());
+        OutputDebugStringW(_ttc(strIdAllNinjaCurrent).to_utf16().c_str() + L'\n');
 #endif  // _DEBUG
     }
     return 0;

--- a/src/winsrc/vscode.cpp
+++ b/src/winsrc/vscode.cpp
@@ -402,23 +402,8 @@ bool CDlgVsCode::CreateVsCodeTasks(CSrcFiles& cSrcFiles, ttlib::cstrVector& Resu
     ttlib::textfile tasks;
     tasks.Read(txtTasks);
 
-    ttlib::cstr MakeFileOption;
-    // BUGBUG: [KeyWorks - 05-08-2020] Issue #242 means this option is no longer used -- need a different way to determine
-    // whether or not to create a task that uses it.
-    if (cSrcFiles.hasOptValue(OPT::MAKE_DIR))
-    {
-        MakeFileOption = cSrcFiles.getOptValue(OPT::MAKE_DIR);
-        if (MakeFileOption.issameas("."))
-            MakeFileOption = "makefile";
-        else
-            MakeFileOption.append_filename("makefile");
-    }
-    else
-    {
-        MakeFileOption = cSrcFiles.GetSrcFilesName();
-        MakeFileOption.replace_filename("makefile");
-    }
-    MakeFileOption.insert(0, "-f ");
+    // All of our tasks assumbe a bld/ directory since that's where ttBld will be creating the ninja files and a makefile
+    ttlib::cstr MakeFileOption("-f bld/makefile");
 
     // Read the array of lines, write them into kf so it looks like it was read from a file
 
@@ -509,6 +494,9 @@ bool CDlgVsCode::CreateVsCodeTasks(CSrcFiles& cSrcFiles, ttlib::cstrVector& Resu
             ;
 #endif
     }
+
+    // At this point the task assume a bld/ directory -- if that needs to change, then we can simply iterate through the out vector and
+    // replace "-f bld/" with whatever the directory should be.
 
     if (!out.WriteFile(".vscode/tasks.json"))
     {
@@ -732,7 +720,7 @@ bool UpdateVsCodeProps(CSrcFiles& cSrcFiles, ttlib::cstrVector& Results)
     if (!Modified)
     {
         Results.emplace_back("c_cpp_properties.json" + _ttc(strIdCurrent));
-        return false;
+        return true;
     }
 
     if (!file.WriteFile(".vscode/c_cpp_properties.json"))


### PR DESCRIPTION
<!-- List the issue (or issues) this branch will fix -->
Fixes #236

### Description:
This PR does two things: it changes the creation of `.vscode/tasks.json` to use `-f bld/makefile` as the default build command, and it ensures that the initial `makefile` file gets created even if the `bld/` directory did not initially exist.


