### PR TITLE
Overhaul versioning in .srcfiles.yaml

### DIFF
--- a/src/pch.h
+++ b/src/pch.h
@@ -66,9 +66,11 @@ namespace fs = std::filesystem;
 
 #include "strings.h"
 
-constexpr const auto txtVersion = "ttBld 1.7.1";
-constexpr const auto txtCopyRight = "Copyright (c) 2002-2020 KeyWorks Software";
-constexpr const auto txtAppname = "ttBld";
+// Version is also set in writesrc.h and ttBld.rc -- if changed, change in all three locations
+
+inline constexpr const auto txtVersion = "ttBld 1.7.1";
+inline constexpr const auto txtCopyRight = "Copyright (c) 2002-2020 KeyWorks Software";
+inline constexpr const auto txtAppname = "ttBld";
 
 // Use THROW to throw this exception class
 class CExcept

--- a/src/ttBld.rc
+++ b/src/ttBld.rc
@@ -35,7 +35,7 @@ BEGIN
             VALUE "Comments", "Released under Apache License\0"
             VALUE "CompanyName", "KeyWorks Software\0"
             VALUE "FileDescription", "Ninja Build Script generator\0"
-            VALUE "FileVersion", "1.7.0.0\0"
+            VALUE "FileVersion", "1.7.1.0\0"
             VALUE "InternalName", "ttBld\0"
             VALUE "LegalCopyright", "Copyright (c) 2002-2020 KeyWorks Software\0"
             VALUE "LegalTrademarks", "\0"

--- a/src/writesrc.cpp
+++ b/src/writesrc.cpp
@@ -31,14 +31,11 @@ bld::RESULT CWriteSrcFiles::UpdateOptions(std::string_view filename)
 
     ttlib::textfile out;
 
-    // Always write out the version number required and the github URL for ttBld
+    // Always write the version of ttBld.exe used. That way if an older version is used and an option line gets commented out, the user
+    // might spot that an earlier version of ttBld is being used (if tracked by SCM, it will show up in the diff)
 
-    {
-        ttlib::cstr str;
-        str.Format(txtNinjaVerFormat, GetMajorRequired(), GetMinorRequired(), GetSubRequired());
-        out.emplace_back(str);
-        out.addEmptyLine();
-    }
+    out.emplace_back(txtNinjaVerFormat);
+    out.addEmptyLine();
 
     size_t pos = 0;
     bool SeenRequiredComment = false;
@@ -47,7 +44,8 @@ bld::RESULT CWriteSrcFiles::UpdateOptions(std::string_view filename)
         // Ignore any previous comment about ttBld since we've already written it.
         if (!SeenRequiredComment)
         {
-            if (orgFile[pos].size() && ttlib::is_sameprefix(orgFile[pos], "# Requires ttBld", tt::CASE::either))
+            if (orgFile[pos].size() && (ttlib::is_sameprefix(orgFile[pos], "# Requires ttBld", tt::CASE::either) ||
+                                        ttlib::is_sameprefix(orgFile[pos], "# Updated by ttBld", tt::CASE::either)))
             {
                 ++pos;
                 if (orgFile[pos].empty())
@@ -97,7 +95,7 @@ bld::RESULT CWriteSrcFiles::UpdateOptions(std::string_view filename)
         if (option == OPT::LAST)
         {
             auto& line = out.addEmptyLine();
-            line.assign("    # invalid option -- ");
+            line.assign("    # unrecognized option -- ");
             line += orgFile[pos];
             continue;
         }

--- a/src/writesrc.h
+++ b/src/writesrc.h
@@ -10,8 +10,7 @@
 
 #include "csrcfiles.h"
 
-constexpr const char* txtNinjaVerFormat =
-    "# Requires ttBld.exe version %d.%d.%d or higher to process -- see https://github.com/KeyWorksRW/ttBld";
+inline constexpr const char* txtNinjaVerFormat = "# Updated by ttBld.exe version 1.7 -- see https://github.com/KeyWorksRW/ttBld";
 
 // This class inherits from CSrcFiles and can be used anywhere CSrcFiles is used.
 class CWriteSrcFiles : public CSrcFiles
@@ -19,22 +18,17 @@ class CWriteSrcFiles : public CSrcFiles
 public:
     CWriteSrcFiles();
 
-    // Public functions
-
-    // Write updates to the Options: section only. Rest if the file is written unchanged.
+    // Write updates to the Options: section only. Rest of the file is written unchanged.
     bld::RESULT UpdateOptions(std::string_view filename = ttlib::emptystring);
 
     // The default filename is determined by the current platform. .srcfiles.win.yaml for
     // Windows, .srcfiles.unix.yaml for Unix, etc.
     //
     // If specified, comment will be added at he the top of the file after the ttBld
-    // requirement line.
+    // version line.
     bld::RESULT WriteNew(std::string_view filename = ttlib::emptystring, std::string_view comment = ttlib::emptystring);
 
-protected:
 private:
-    // Class members
-
     ttlib::cstr m_outFilename;
     ttlib::cstr m_fileComment;  // comment to appear at the top of the file
 };


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes the way **ttBld** deals with newer and older versions of `.srcfiles.yaml` files. The top line is now always rewritten and states the version of **ttBld** that updated the file.

If the current version of **ttBld** encounters an option it doesn't recognize, it places the option in a comment line starting with:
 
```# unrecognized option --```

When the file is read, if the commented-out option _is_ now recognized, it will be parsed normally as if it wasn't a comment line. If the file is written (OK pressed in Options Dialog), then the line is written out without the comment prefix.

What this means is that an older version of **ttBld** can comment out an option it doesn't recognize, but it will still work fine in a newer version of **ttBld**.

Note that this works fine as long as the Options Dialog is used to write the file. If the user edits this option line by hand, all bets are off since they may well have accidentally turned it into an invalid option.
