### PR TITLE
Add -hgz command

### DIFF
--- a/src/.srcfiles.yaml
+++ b/src/.srcfiles.yaml
@@ -33,6 +33,7 @@ Files:
     finder.cpp          # Routines for finding executables such as the MSVC compiler
     gencmdfiles.cpp     # Generates MSVCenv.cmd and Code.cmd files
     gitfuncs.cpp        # Functions for working with .git
+    make_hgz.cpp        # Converts a file into a .gz and stores as char array header
     ninja.cpp           # CNinja for creating .ninja scripts
     options.cpp         # contains all Options strings and CSrcOptions class for working with them
     rcdep.cpp           # Contains functions for parsing RC dependencies

--- a/src/bld/msvc_dbg.ninja
+++ b/src/bld/msvc_dbg.ninja
@@ -54,6 +54,8 @@ build $outdir/gencmdfiles.obj: compile gencmdfiles.cpp | $outdir/pch.obj
 
 build $outdir/gitfuncs.obj: compile gitfuncs.cpp | $outdir/pch.obj
 
+build $outdir/make_hgz.obj: compile make_hgz.cpp | $outdir/pch.obj
+
 build $outdir/ninja.obj: compile ninja.cpp | $outdir/pch.obj
 
 build $outdir/options.obj: compile options.cpp | $outdir/pch.obj
@@ -110,6 +112,7 @@ build ../bin/ttBldD.exe : link $resout/ttBldD.res $
   $outdir/finder.obj $
   $outdir/gencmdfiles.obj $
   $outdir/gitfuncs.obj $
+  $outdir/make_hgz.obj $
   $outdir/ninja.obj $
   $outdir/options.obj $
   $outdir/rcdep.obj $

--- a/src/bld/msvc_rel.ninja
+++ b/src/bld/msvc_rel.ninja
@@ -55,6 +55,8 @@ build $outdir/gencmdfiles.obj: compile gencmdfiles.cpp | $outdir/pch.obj
 
 build $outdir/gitfuncs.obj: compile gitfuncs.cpp | $outdir/pch.obj
 
+build $outdir/make_hgz.obj: compile make_hgz.cpp | $outdir/pch.obj
+
 build $outdir/ninja.obj: compile ninja.cpp | $outdir/pch.obj
 
 build $outdir/options.obj: compile options.cpp | $outdir/pch.obj
@@ -111,6 +113,7 @@ build ../bin/ttBld.exe : link $resout/ttBld.res $
   $outdir/finder.obj $
   $outdir/gencmdfiles.obj $
   $outdir/gitfuncs.obj $
+  $outdir/make_hgz.obj $
   $outdir/ninja.obj $
   $outdir/options.obj $
   $outdir/rcdep.obj $

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -58,6 +58,7 @@
 #endif
 
 void AddFiles(const ttlib::cstrVector& lstFiles);
+int MakeHgz(ttlib::cstrVector& files);
 
 enum UPDATE_TYPE
 {
@@ -146,6 +147,8 @@ int CMainApp::OnRun()
     cmd.addHiddenOption("uclangD");
     cmd.addHiddenOption("uclang_x86D");
 
+    cmd.addHiddenOption("hgz");  // -hgz src dst (converts src into -gz, saves as char array header file)
+
 #if defined(TESTING) && !defined(NDEBUG)
     cmd.addHiddenOption("tvdlg", ttlib::cmd::needsarg);
 #endif
@@ -162,6 +165,11 @@ int CMainApp::OnRun()
             std::cout << iter << '\n';
         }
         return 0;
+    }
+
+    if (cmd.isOption("hgz"))
+    {
+        return MakeHgz(cmd.getExtras());
     }
 
     UPDATE_TYPE upType = UPDATE_NORMAL;

--- a/src/make_hgz.cpp
+++ b/src/make_hgz.cpp
@@ -1,0 +1,144 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Converts a file into a .gz and stores as char array header
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2020 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#include "pch.h"
+
+#include <fstream>
+#include <iostream>
+
+#include <wx/archive.h>   // Streams for archive formats
+#include <wx/file.h>      // wxFile - encapsulates low-level "file descriptor"
+#include <wx/mstream.h>   // Memory stream classes
+#include <wx/stream.h>    // stream classes
+#include <wx/wfstream.h>  // File stream classes
+
+#include <ttcvector.h>   // Vector of ttlib::cstr strings
+#include <tttextfile.h>  // textfile -- Classes for reading and writing line-oriented files
+
+static bool CopyStreamData(wxInputStream& inputStream, wxOutputStream& outputStream, wxFileOffset size);
+
+int MakeHgz(ttlib::cstrVector& files)
+{
+    if (files.size() < 2)
+    {
+        std::cerr << "both src and dest files must be specified" << '\n';
+        return 1;
+    }
+
+    auto filterClassFactory = wxFilterClassFactory::Find(".gz", wxSTREAM_FILEEXT);
+    if (!filterClassFactory)
+    {
+        std::cerr << "internal error -- .gz support not enabled" << '\n';
+        return 1;
+    }
+
+    wxFileInputStream inputFileStream(files[0]);
+    auto len = inputFileStream.GetLength();
+    if (!inputFileStream.IsOk())
+    {
+        std::cerr << _tt(strIdCantOpen) << files[0] << '\n';
+        return 1;
+    }
+
+    wxMemoryOutputStream stream_out;
+
+    wxScopedPtr<wxFilterOutputStream> filterOutputStream(filterClassFactory->NewStream(stream_out));
+    if (!CopyStreamData(inputFileStream, *filterOutputStream, inputFileStream.GetLength()))
+    {
+        std::cerr << _tt(strIdInternalError) << '\n';
+        return 1;
+    }
+    filterOutputStream->Close();
+
+    auto strm_buffer = stream_out.GetOutputStreamBuffer();
+    strm_buffer->Seek(0, wxFromStart);
+
+    ttlib::textfile file;
+    {
+        file.addEmptyLine() << "// .gz version of " << files[0].filename();
+        file.addEmptyLine();
+        file.addEmptyLine() << "#pragma once";
+        file.addEmptyLine();
+
+        ttlib::cstr str_name = files[0].filename();
+        ttlib::cstr ext = str_name.extension();
+        str_name.remove_extension();
+        if (ext.size())
+        {
+            // replace the leading '.' with a '_' so that it looks like a more normal string
+            ext[0] = '_';
+            str_name << ext;
+        }
+        str_name << "_gz";
+
+        file.addEmptyLine() << "static const unsigned char " << str_name << '[' << strm_buffer->GetBufferSize() << "] = {";
+    }
+
+    auto buf = static_cast<unsigned char*>(strm_buffer->GetBufferStart());
+
+    size_t pos = 0;
+
+    while (pos < strm_buffer->GetBufferSize())
+    {
+        {
+            auto& line = file.addEmptyLine();
+            for (; pos < strm_buffer->GetBufferSize() && line.size() < 116; ++pos)
+            {
+                line << static_cast<int>(buf[pos]) << ',';
+            }
+        }
+        ++pos;
+    }
+
+    if (file[file.size() - 1].back() == ',')
+        file[file.size() - 1].pop_back();
+
+    file.addEmptyLine() << "};";
+
+    if (!file.WriteFile(files[1]))
+    {
+        std::cerr << _tt(strIdCantWrite) << files[1];
+        return 1;
+    }
+
+    return 0;
+}
+
+static bool CopyStreamData(wxInputStream& inputStream, wxOutputStream& outputStream, wxFileOffset size)
+{
+    wxChar buf[128 * 1024];
+    int readSize = 128 * 1024;
+    wxFileOffset copiedData = 0;
+    for (;;)
+    {
+        if (size != -1 && copiedData + readSize > size)
+            readSize = size - copiedData;
+        inputStream.Read(buf, readSize);
+
+        size_t actuallyRead = inputStream.LastRead();
+        outputStream.Write(buf, actuallyRead);
+        if (outputStream.LastWrite() != actuallyRead)
+        {
+            // wxLogError("Failed to output data");
+            return false;
+        }
+
+        if (size == -1)
+        {
+            if (inputStream.Eof())
+                break;
+        }
+        else
+        {
+            copiedData += actuallyRead;
+            if (copiedData >= size)
+                break;
+        }
+    }
+
+    return true;
+}

--- a/src/make_hgz.cpp
+++ b/src/make_hgz.cpp
@@ -81,17 +81,17 @@ int MakeHgz(ttlib::cstrVector& files)
     auto buf = static_cast<unsigned char*>(strm_buffer->GetBufferStart());
 
     size_t pos = 0;
+    auto buf_size = strm_buffer->GetBufferSize();
 
-    while (pos < strm_buffer->GetBufferSize())
+    while (pos < buf_size)
     {
         {
             auto& line = file.addEmptyLine();
-            for (; pos < strm_buffer->GetBufferSize() && line.size() < 116; ++pos)
+            for (; pos < buf_size && line.size() < 116; ++pos)
             {
                 line << static_cast<int>(buf[pos]) << ',';
             }
         }
-        ++pos;
     }
 
     if (file[file.size() - 1].back() == ',')

--- a/src/pch.h
+++ b/src/pch.h
@@ -68,7 +68,7 @@ namespace fs = std::filesystem;
 
 // Version is also set in writesrc.h and ttBld.rc -- if changed, change in all three locations
 
-inline constexpr const auto txtVersion = "ttBld 1.7.1";
+inline constexpr const auto txtVersion = "ttBld 1.7.2";
 inline constexpr const auto txtCopyRight = "Copyright (c) 2002-2020 KeyWorks Software";
 inline constexpr const auto txtAppname = "ttBld";
 

--- a/src/precompile/pch.h
+++ b/src/precompile/pch.h
@@ -81,6 +81,6 @@ namespace fs = std::filesystem;
 
 #include "strings.h"
 
-constexpr const auto txtVersion = "ttBld 1.7.0";
+constexpr const auto txtVersion = "ttBld 1.7.2";
 constexpr const auto txtCopyRight = "Copyright (c) 2002-2020 KeyWorks Software";
 constexpr const auto txtAppname = "ttBld";

--- a/src/ttBld.rc
+++ b/src/ttBld.rc
@@ -35,7 +35,7 @@ BEGIN
             VALUE "Comments", "Released under Apache License\0"
             VALUE "CompanyName", "KeyWorks Software\0"
             VALUE "FileDescription", "Ninja Build Script generator\0"
-            VALUE "FileVersion", "1.7.1.0\0"
+            VALUE "FileVersion", "1.7.2.0\0"
             VALUE "InternalName", "ttBld\0"
             VALUE "LegalCopyright", "Copyright (c) 2002-2020 KeyWorks Software\0"
             VALUE "LegalTrademarks", "\0"

--- a/src/writesrc.h
+++ b/src/writesrc.h
@@ -10,7 +10,7 @@
 
 #include "csrcfiles.h"
 
-inline constexpr const char* txtNinjaVerFormat = "# Updated by ttBld.exe version 1.7 -- see https://github.com/KeyWorksRW/ttBld";
+inline constexpr const char* txtNinjaVerFormat = "# Updated by ttBld.exe version 1.7.2 -- see https://github.com/KeyWorksRW/ttBld";
 
 // This class inherits from CSrcFiles and can be used anywhere CSrcFiles is used.
 class CWriteSrcFiles : public CSrcFiles


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a hidden `-hgz` command which takes an input file, compresses it into **.gz** format and writes it out to a header file containing an `unsigned character` array. This file can then be compiled into a program and the original file extracted at run time.

With **Windows** programs, a file can simply be included in the resource file and it will be compiled into the executable file. Unix/Mac programs don't have that capability, so you need to convert the file into an array and compile it into the program. The program **bin2c** will do that, but this PR takes it one step further and compresses the file into `.gz` first, and then writes it out in a way that is efficient for the compiler, at the cost of not looking pretty for a human reader.

The reason for the command being hidden is that I'm thinking about adding a `GZ:` section to `.srcfiles.yaml` which would let you setup source/destination pairs which would then be used to write dependencies into the **ninja** script so that **ttBld** would be called by **ninja** whenever a file needed to be updated as part of the compilation process. Once that's in place, there wouldn't be much need to expose the switch -- it would make more sense to just have it part of the build process. Until then, it's available to anyone that wants to experiment with it.
