### PR TITLE
Add GZIP: section to .srcfiles, used to create ninja build rules for the gzip header array

### DIFF
--- a/src/csrcfiles.cpp
+++ b/src/csrcfiles.cpp
@@ -349,7 +349,7 @@ void CSrcFiles::ProcessGzipLine(std::string_view line)
     ttlib::multistr pair(line, ':');
     if (pair.size() < 2)
     {
-        AddError(_tt("Expected \"header: source\" but ':' not found seperating the two"));
+        AddError(_tt("Expected \"source: header\" but ':' not found seperating the two"));
         return;
     }
 

--- a/src/csrcfiles.cpp
+++ b/src/csrcfiles.cpp
@@ -340,14 +340,9 @@ void CSrcFiles::ProcessDebugFile(std::string_view line)
 
         source.src_ext: header.hdr_ext  # optional comment
 
-        *.src_ext: *.hdr_ext
-
         *.src_ext: header.hdr_ext
 
     In the above case all files matching *.src_ext will be converted into arrays in header.hdr_ext
-
-    The reason for putting the source file first is because it is valid to have multiple source files with a single
-    destination.
 */
 void CSrcFiles::ProcessGzipLine(std::string_view line)
 {

--- a/src/csrcfiles.h
+++ b/src/csrcfiles.h
@@ -177,6 +177,7 @@ protected:
     const ttlib::cstr& GetReportFilename() { return m_ReportPath; }
 
 protected:
+    void ProcessGzipLine(std::string_view line);
     ttlib::cstr m_LIBname;  // Name and location of any additional library to build (used by Lib: section)
     ttlib::cstr m_RCname;   // Resource file to build (if any)
     ttlib::cstr m_HPPname;  // HTML Help project file
@@ -184,6 +185,8 @@ protected:
     ttlib::cstrVector m_lstSrcFiles;    // List of all source files except DEBUG build files
     ttlib::cstrVector m_lstIdlFiles;    // List of any idl files to compile with midl compiler
     ttlib::cstrVector m_lstDebugFiles;  // List of all source files for DEBUG builds only
+
+    std::map<std::string, std::string> m_gzip_files;  // Map of header/source filename pairs
 
     ttlib::cstrVector m_lstIncludeSrcFiles;
 
@@ -213,6 +216,7 @@ private:
         SECTION_OPTIONS,
         SECTION_FILES,
         SECTION_DEBUG_FILES,
+        SECTION_GZIP,
     };
     SRC_SECTION m_section { SECTION_UNKNOWN };
 

--- a/src/csrcfiles.h
+++ b/src/csrcfiles.h
@@ -186,7 +186,7 @@ protected:
     ttlib::cstrVector m_lstIdlFiles;    // List of any idl files to compile with midl compiler
     ttlib::cstrVector m_lstDebugFiles;  // List of all source files for DEBUG builds only
 
-    std::map<std::string, std::string> m_gzip_files;  // Map of header/source filename pairs
+    std::map<ttlib::cstr, std::string> m_gzip_files;  // Map of header/source filename pairs
 
     ttlib::cstrVector m_lstIncludeSrcFiles;
 

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -147,7 +147,7 @@ int CMainApp::OnRun()
     cmd.addHiddenOption("uclangD");
     cmd.addHiddenOption("uclang_x86D");
 
-    cmd.addHiddenOption("hgz");  // -hgz src dst (converts src into -gz, saves as char array header file)
+    cmd.addHiddenOption("hgz");  // -hgz dst src (converts src into -gz, saves as char array header file)
 
 #if defined(TESTING) && !defined(NDEBUG)
     cmd.addHiddenOption("tvdlg", ttlib::cmd::needsarg);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR makes two changes to GZIP processung. First, it flips the order of options passed to the -hgz command. The destination header file is now first and multiple source files can the be specified. Secondly, this adds support for a GZIP: section in .srcfiles.yaml.

For small source files, such as **XPM** files, it might be convenient for the user to write them all into a single header file. The **GZIP:** section in **.srcfiles** supports using a wildcard in the source file name. This will result in all files matching the wildcard added as gzip arrays in the specified header file. Note that this required changing the comment header of the output file so that the array name of each src file is specified as a comment line at the top. This makes it easy to see the array names of every src file that got converted to a **gzip** array.
