### PR TITLE
Add XPM: and -xpm section/build support

### DIFF
--- a/src/csrcfiles.cpp
+++ b/src/csrcfiles.cpp
@@ -84,6 +84,10 @@ bool CSrcFiles::ReadFile(std::string_view filename)
             {
                 m_section = SECTION_GZIP;
             }
+            else if (ttlib::is_sameprefix(line, "XPM:", tt::CASE::either) || ttlib::is_sameprefix(line, "[XPM]", tt::CASE::either))
+            {
+                m_section = SECTION_XPM;
+            }
             else if (ttlib::is_sameprefix(line, "Options:", tt::CASE::either) || ttlib::is_sameprefix(line, "[OPTIONS]"))
             {
                 m_section = SECTION_OPTIONS;
@@ -135,6 +139,10 @@ bool CSrcFiles::ReadFile(std::string_view filename)
 
             case SECTION_GZIP:
                 ProcessGzipLine(begin);
+                break;
+
+            case SECTION_XPM:
+                ProcessXpmLine(begin);
                 break;
 
             case SECTION_OPTIONS:
@@ -358,6 +366,31 @@ void CSrcFiles::ProcessGzipLine(std::string_view line)
     pair[1].trim(tt::TRIM::both);
 
     m_gzip_files[pair[0]] = pair[1];
+}
+
+/*
+    Lines are expected to be of the form:
+
+    source.ext: dst.xpm  # optional comment
+
+*/
+void CSrcFiles::ProcessXpmLine(std::string_view line)
+{
+    ttlib::multistr pair(line, ':');
+    if (pair.size() < 2)
+    {
+        AddError(_tt("Expected \"source: header\" but ':' not found seperating the two"));
+        return;
+    }
+
+    pair[0].trim(tt::TRIM::both);
+    pair[1].erase_from('#');
+    pair[1].trim(tt::TRIM::both);
+
+    if (pair[1].extension().empty())
+        pair[1].replace_extension(".xpm");
+
+    m_xpm_files[pair[0]] = pair[1];
 }
 
 // Process a ".include" directive

--- a/src/csrcfiles.h
+++ b/src/csrcfiles.h
@@ -178,6 +178,8 @@ protected:
 
 protected:
     void ProcessGzipLine(std::string_view line);
+    void ProcessXpmLine(std::string_view line);
+
     ttlib::cstr m_LIBname;  // Name and location of any additional library to build (used by Lib: section)
     ttlib::cstr m_RCname;   // Resource file to build (if any)
     ttlib::cstr m_HPPname;  // HTML Help project file
@@ -187,6 +189,7 @@ protected:
     ttlib::cstrVector m_lstDebugFiles;  // List of all source files for DEBUG builds only
 
     std::map<ttlib::cstr, std::string> m_gzip_files;  // Map of header/source filename pairs
+    std::map<ttlib::cstr, ttlib::cstr> m_xpm_files;   // Map of src/dst filename pairs
 
     ttlib::cstrVector m_lstIncludeSrcFiles;
 
@@ -217,6 +220,7 @@ private:
         SECTION_FILES,
         SECTION_DEBUG_FILES,
         SECTION_GZIP,
+        SECTION_XPM,
     };
     SRC_SECTION m_section { SECTION_UNKNOWN };
 

--- a/src/ninja.cpp
+++ b/src/ninja.cpp
@@ -165,7 +165,18 @@ bool CNinja::CreateBuildFile(GEN_TYPE gentype, CMPLR_TYPE cmplr)
         m_ninjafile.emplace_back("  command = ttBld -hgz $out $in");
         m_ninjafile.emplace_back("  description = converting $in into $out");
         m_ninjafile.addEmptyLine();
+    }
 
+    if (m_xpm_files.size())
+    {
+        m_ninjafile.emplace_back("rule xpmConversion");
+        m_ninjafile.emplace_back("  command = ttBld -xpm $in $out");
+        m_ninjafile.emplace_back("  description = converting $in into $out");
+        m_ninjafile.addEmptyLine();
+    }
+
+    if (m_gzip_files.size())
+    {
         for (auto& iter: m_gzip_files)
         {
             if (iter.first.contains("*") || iter.first.contains("?"))
@@ -197,6 +208,15 @@ bool CNinja::CreateBuildFile(GEN_TYPE gentype, CMPLR_TYPE cmplr)
             {
                 m_ninjafile.addEmptyLine().Format("build %s: gzipHeader %s", iter.second.c_str(), iter.first.c_str());
             }
+            m_ninjafile.addEmptyLine();
+        }
+    }
+
+    if (m_xpm_files.size())
+    {
+        for (auto& iter: m_xpm_files)
+        {
+            m_ninjafile.addEmptyLine().Format("build %s: xpmConversion %s", iter.second.c_str(), iter.first.c_str());
             m_ninjafile.addEmptyLine();
         }
     }


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR allows adding an `XPM:` section containing `src: dst` pairs that can be used to convert an image into an XPM file.

A common workflow is to create/modify artwork as a PNG file, then convert it to XPM where it gets compiled into the program using a `#include` directive. However, while programs like Greenfish are excellent tools for editing the images, the XPM they generate is quite different from the XPM files that **wxWidgets** releases. There's technically nothing wrong with it, though the lack of a `const` keyword might result in sub-optimal compilation. A bigger problem is when the XPM file is being tracked by SCM (e.g., .git) -- changing the output format results in the entire file being listed as different. If the file was always generated by the same tool, then as long as the dimensions of the image don't change, then the difference will be minimal.

The code uses **wxWidgets** to both load the image and to save it as a XPM file. That provides a consistent output file format, and **wxWidgets** handles all of the most common graphics file formats, so the original image type likely to be used (PNG, BMP, ICO, etc.) will be supported.
