### PR TITLE
Update to current KeyWorks standards

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-# https://releases.llvm.org/9.0.0/tools/clang/docs/ClangFormatStyleOptions.html
+# https://releases.llvm.org/11.0.0/tools/clang/docs/ClangFormatStyleOptions.html
 
 AlignConsecutiveMacros: true
 AllowAllArgumentsOnNextLine: true
@@ -26,12 +26,12 @@ BinPackParameters: true
 BraceWrapping:
   AfterClass:      true
   AfterControlStatement: true
-  AfterEnum:       true
-  AfterFunction:   true
-  AfterNamespace:  true
+  AfterEnum:        true
+  AfterFunction:    true
+  AfterNamespace:   true
   AfterObjCDeclaration: true
-  AfterStruct:     true
-  AfterUnion:      true
+  AfterStruct:      true
+  AfterUnion:       true
   AfterExternBlock: true
   BeforeCatch:     false
   BeforeElse:      true
@@ -47,7 +47,7 @@ BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: AfterColon
 BreakInheritanceList: AfterColon
 BreakStringLiterals: true
-ColumnLimit: 140
+ColumnLimit: 125
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
@@ -72,8 +72,6 @@ IndentPPDirectives: BeforeHash
 IndentWidth:     4
 IndentWrappedFunctionNames: true
 KeepEmptyLinesAtTheStartOfBlocks: false
-MacroBlockBegin: 'BEGIN_TTCMD_MAP|BEGIN_TTMSG_MAP|wxBEGIN_EVENT_TABLE|wxDECLARE_EXPORTED_EVENT|BEGIN_MSG_MAP'
-MacroBlockEnd: 'END_TTMSG_MAP|wxEND_EVENT_TABLE|END_MSG_MAP'
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: All
 PointerAlignment: Left

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ build/
 
 .private/
 archive/
-backup/
+converted_art/
 tests/
 
 # Generated files to ignore
@@ -69,19 +69,19 @@ build/
 # VSCode files
 .vscode/
 *.code-workspace
+*.code-search
 
 # Visual Studio files and folders
 # Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
 # User-specific files
+*.filters
 *.rsuser
+*.sln
+*.sln.docstates
 *.suo
 *.user
 *.userosscache
-*.sln.docstates
-*.sln
-
-*.filters
 *.vcproj
 *.vcxproj
 


### PR DESCRIPTION
Line length is now 125 instead of 140.

Additional ignores added for vs code and wxUiEditor.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR updates .clang-format and .gitignore to make them consistent with other KeyWorks projects.