### PR TITLE
Expand support for 32-bit Build Libraries

### DIFF
--- a/src/cmplrMsvc.cpp
+++ b/src/cmplrMsvc.cpp
@@ -318,12 +318,18 @@ void CNinja::msvcWriteLibDirective(CMPLR_TYPE cmplr)
     auto& line = m_ninjafile.addEmptyLine();
     if (cmplr == CMPLR_MSVC)
     {
-        line.Format("  command = lib.exe /MACHINE:%s /LTCG /NOLOGO /OUT:$out $in", (isOptTrue(OPT::BIT32) ? "x86" : "x64"));
+        if (m_gentype == GEN_DEBUG || m_gentype == GEN_RELEASE)
+            line << "  command = lib.exe /MACHINE:x64 /LTCG /NOLOGO /OUT:$out $in";
+        else
+            line << "  command = lib.exe /MACHINE:x86 /LTCG /NOLOGO /OUT:$out $in";
     }
     else
     {
-        // MSVC -LTCG option is not supported by lld
-        line.Format("  command = lld-link.exe /lib /machine:%s /out:$out $in", (isOptTrue(OPT::BIT32)) ? "x86" : "x64");
+        if (m_gentype == GEN_DEBUG || m_gentype == GEN_RELEASE)
+            // MSVC -LTCG option is not supported by lld
+            line << "  command = lld-link.exe /lib /machine:x64 /out:$out $in";
+        else
+            line << "  command = lld-link.exe /lib /machine:x86 /out:$out $in";
     }
     m_ninjafile.emplace_back("  description = creating library $out");
     m_ninjafile.addEmptyLine();

--- a/src/csrcfiles.cpp
+++ b/src/csrcfiles.cpp
@@ -698,7 +698,7 @@ const ttlib::cstr& CSrcFiles::GetTargetDebug()
 const ttlib::cstr& CSrcFiles::GetTargetDebug32()
 {
     if (m_dbgTarget32.size())
-        return m_dbgTarget;
+        return m_dbgTarget32;
 
     m_dbgTarget32 = m_Options[OPT::TARGET_DIR32].value;
     ASSERT_MSG(m_dbgTarget32.size(), "Don't call GetTargetDebug32 if OPT::TARGET_DIR32 is empty!");

--- a/src/ninja.cpp
+++ b/src/ninja.cpp
@@ -656,7 +656,7 @@ void CNinja::ProcessBuildLibs32()
         assertm(!cSrcFiles.GetTargetRelease().empty(), "Must have a release library target");
         assertm(!cSrcFiles.GetTargetDebug().empty(), "Must have a debug library target");
 
-        if (cSrcFiles.GetTargetRelease().empty() || cSrcFiles.GetTargetDebug().empty())
+        if (cSrcFiles.GetTargetRelease32().empty() || cSrcFiles.GetTargetDebug32().empty())
         {
             AddError("Invalid .srcfiles.yaml: " + BuildFile);
             continue;
@@ -674,11 +674,11 @@ void CNinja::ProcessBuildLibs32()
         bldLib.libPathDbg.assignCwd();
         bldLib.libPathRel = bldLib.libPathDbg;
 
-        bldLib.libPathDbg.append_filename(cSrcFiles.GetTargetDebug());
+        bldLib.libPathDbg.append_filename(cSrcFiles.GetTargetDebug32());
         bldLib.libPathDbg.make_relative(cwd);
         bldLib.libPathDbg.backslashestoforward();
 
-        bldLib.libPathRel.append_filename(cSrcFiles.GetTargetRelease());
+        bldLib.libPathRel.append_filename(cSrcFiles.GetTargetRelease32());
         bldLib.libPathRel.make_relative(cwd);
         bldLib.libPathRel.backslashestoforward();
     }


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR expands support for 32-bit Build Libraries by allowing the same name with a different directly (such as lib32/) and fixes the lib command which was using the wrong machine code.

A BuildLib32 library can now either be in a shared directory with a unique name (which requires a separate .srcrfiles.yaml) or in a unique directory (such as lib32/) with a common name.
