### PR TITLE
Fix rule names for PNG conversion

### DIFF
--- a/src/ninja.cpp
+++ b/src/ninja.cpp
@@ -188,7 +188,7 @@ bool CNinja::CreateBuildFile(GEN_TYPE gentype, CMPLR_TYPE cmplr)
 
     if (m_png_files.size())
     {
-        m_ninjafile.emplace_back("rule xpmConversion");
+        m_ninjafile.emplace_back("rule pngConversion");
         m_ninjafile.emplace_back("  command = ttBld -png $in $out");
         m_ninjafile.emplace_back("  description = converting $in into $out");
         m_ninjafile.addEmptyLine();
@@ -244,7 +244,7 @@ bool CNinja::CreateBuildFile(GEN_TYPE gentype, CMPLR_TYPE cmplr)
     {
         for (auto& iter: m_png_files)
         {
-            m_ninjafile.addEmptyLine().Format("build %s: xpmConversion %s", iter.second.c_str(), iter.first.c_str());
+            m_ninjafile.addEmptyLine().Format("build %s: pngConversion %s", iter.second.c_str(), iter.first.c_str());
             m_ninjafile.addEmptyLine();
         }
     }


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
The -png option was working fine, but the ninja script generation was incorrect.