### PR TITLE
Trim pcdata when reading an XML file

### DIFF
--- a/src/make_hgz.cpp
+++ b/src/make_hgz.cpp
@@ -46,7 +46,7 @@ int MakeHgz(ttlib::cstrVector& files)
     if (files[1].has_extension(".xml"))
     {
         pugi::xml_document doc;
-        auto result = doc.load_file(files[1].c_str());
+        auto result = doc.load_file(files[1].c_str(), pugi::parse_default | pugi::parse_trim_pcdata);
 
         if (result)
         {


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR changes the input processing of XML files using the -hgz command such that the pcdata is trimmed (leading and trailing whitespace removed). This is primarily for **wxUiEditor** which often has the pcdata on it's own line, indented to the current node depth (creating leading whitespace). Stripping it not only reduces the size of the file, but also reduces the runtime processing since trimming was taken care of during build time.