### PR TITLE
Refactor using << instead of ++

### DIFF
--- a/src/convert/convert.cpp
+++ b/src/convert/convert.cpp
@@ -170,7 +170,7 @@ bld::RESULT CConvert::ConvertSrcfiles(const std::string& srcFile, std::string_vi
             cszRelative.assign(iter);
             cszRelative.make_absolute();
             cszRelative.make_relative(cszCurCwd);
-            IncDirs += (";" + cszRelative);
+            IncDirs << ';' << cszRelative;
         }
 
         cszRelative += srcOrg.getOptValue(OPT::INC_DIRS);

--- a/src/convert/readdsp.cpp
+++ b/src/convert/readdsp.cpp
@@ -150,17 +150,19 @@ bld::RESULT CConvert::ConvertDsp(const std::string& srcFile, std::string_view ds
                     CurFlags = m_writefile.getOptValue(OPT::CFLAGS_CMN);
                 if (inReleaseSection && m_writefile.hasOptValue(OPT::CFLAGS_REL))
                 {
-                    if (!CurFlags.empty())
-                        CurFlags += " ";
-                    CurFlags += m_writefile.getOptValue(OPT::CFLAGS_REL);
+                    if (CurFlags.size())
+                    {
+                        CurFlags << ' ';
+                    }
+                    CurFlags << m_writefile.getOptValue(OPT::CFLAGS_REL);
                 }
                 else if (!inReleaseSection && m_writefile.hasOptValue(OPT::CFLAGS_DBG))
                 {
-                    if (!CurFlags.empty())
+                    if (CurFlags.size())
                     {
-                        CurFlags += " ";
-                        CurFlags += m_writefile.getOptValue(OPT::CFLAGS_DBG);
+                        CurFlags << ' ';
                     }
+                    CurFlags << m_writefile.getOptValue(OPT::CFLAGS_DBG);
                 }
 
                 auto pos = line.find("/D");
@@ -176,9 +178,11 @@ bld::RESULT CConvert::ConvertDsp(const std::string& srcFile, std::string_view ds
                             // If we don't already have the flag, then add it
                             if (!Flag.contains(CurFlags))
                             {
-                                if (!NewFlags.empty())
-                                    NewFlags += " ";
-                                NewFlags += Flag.c_str();
+                                if (NewFlags.size())
+                                {
+                                    NewFlags << ' ';
+                                }
+                                NewFlags << Flag;
                             }
                         }
                         pos = line.find("/D", pos);
@@ -189,10 +193,9 @@ bld::RESULT CConvert::ConvertDsp(const std::string& srcFile, std::string_view ds
                 {
                     if (inReleaseSection && m_writefile.hasOptValue(OPT::CFLAGS_REL))
                     {
-                        CurFlags = m_writefile.getOptValue(OPT::CFLAGS_REL);
-                        CurFlags += " ";
+                        CurFlags << m_writefile.getOptValue(OPT::CFLAGS_REL) << ' ';
                     }
-                    CurFlags += NewFlags.c_str();
+                    CurFlags << NewFlags;
                     m_writefile.setOptValue(OPT::CFLAGS_REL, CurFlags);
                 }
             }
@@ -205,15 +208,19 @@ bld::RESULT CConvert::ConvertDsp(const std::string& srcFile, std::string_view ds
 
                 if (line.contains("/mktyplib203", tt::CASE::either) && !CurFlags.contains("/mktyplib203"))
                 {
-                    if (!NewFlags.empty())
-                        NewFlags += " ";
-                    NewFlags += "/mktyplib203";
+                    if (NewFlags.size())
+                    {
+                        NewFlags << ' ';
+                    }
+                    NewFlags << "/mktyplib203";
                 }
                 if (line.contains("/win32", tt::CASE::either) && !CurFlags.contains("/win32"))
                 {
-                    if (!NewFlags.empty())
-                        NewFlags += " ";
-                    NewFlags += "/win32";
+                    if (NewFlags.size())
+                    {
+                        NewFlags << ' ';
+                    }
+                    NewFlags << "/win32";
                 }
 
                 auto pos = line.find("/D");
@@ -229,9 +236,11 @@ bld::RESULT CConvert::ConvertDsp(const std::string& srcFile, std::string_view ds
                             // If we don't already have the flag, then add it
                             if (!Flag.contains(CurFlags))
                             {
-                                if (!NewFlags.empty())
-                                    NewFlags += " ";
-                                NewFlags += Flag.c_str();
+                                if (NewFlags.size())
+                                {
+                                    NewFlags << ' ';
+                                }
+                                NewFlags << Flag;
                             }
                         }
                         pos = line.find("/D", pos);
@@ -243,10 +252,9 @@ bld::RESULT CConvert::ConvertDsp(const std::string& srcFile, std::string_view ds
                 {
                     if (m_writefile.hasOptValue(OPT::MIDL_CMN))
                     {
-                        CurFlags = m_writefile.getOptValue(OPT::MIDL_CMN);
-                        CurFlags += " ";
+                        CurFlags << m_writefile.getOptValue(OPT::MIDL_CMN) << ' ';
                     }
-                    CurFlags += NewFlags.c_str();
+                    CurFlags << NewFlags;
                     m_writefile.setOptValue(OPT::MIDL_CMN, CurFlags);
                 }
             }

--- a/src/convert/readvc.cpp
+++ b/src/convert/readvc.cpp
@@ -188,9 +188,9 @@ void CConvert::ProcessVcRelease(pugi::xml_node node)
                 for (auto& filename: enumPaths)
                 {
                     MakeNameRelative(filename);
-                    if (!Includes.empty())
-                        Includes += ";";
-                    Includes += filename;
+                    if (Includes.size())
+                        Includes << ';';
+                    Includes << filename;
                 }
                 if (!Includes.empty())
                     m_writefile.setOptValue(OPT::INC_DIRS, Includes);
@@ -198,14 +198,13 @@ void CConvert::ProcessVcRelease(pugi::xml_node node)
         }
         else if (name.is_sameas("VCLinkerTool", tt::CASE::either))
         {
-            auto val = tool.attribute("AdditionalDependencies").cvalue();
-            if (!val.empty())
+            if (auto val = tool.attribute("AdditionalDependencies").cvalue(); val.size())
             {
                 m_writefile.setOptValue(OPT::LIBS_DBG, val);
             }
 
             auto filename = tool.attribute("OutputFile").as_cstr();
-            if (!filename.empty() && m_writefile.GetProjectName().empty())
+            if (filename.size() && m_writefile.GetProjectName().empty())
             {
                 filename.remove_extension();
                 m_writefile.setOptValue(OPT::PROJECT, filename.filename());

--- a/src/convert/writevcx.cpp
+++ b/src/convert/writevcx.cpp
@@ -47,20 +47,20 @@ static bool CreateGuid(ttlib::cstr& Result)
 
 bool CVcxWrite::CreateBuildFile()
 {
-    ttlib::cstr cszGuid;
-    if (!CreateGuid(cszGuid))
+    ttlib::cstr guid;
+    if (!CreateGuid(guid))
     {
         AddError(_tt(strIdCantCreateUuid));
         return false;
     }
 
-    ttlib::cstr cszProjVC(GetProjectName());
-    cszProjVC.replace_extension(".vcxproj");
-    if (!cszProjVC.file_exists())
+    ttlib::cstr vc_project_file(GetProjectName());
+    vc_project_file.replace_extension(".vcxproj");
+    if (!vc_project_file.file_exists())
     {
         ttlib::cstr master(ttlib::find_nonspace(res_vcxproj_xml));
 
-        master.Replace("%guid%", cszGuid, true);
+        master.Replace("%guid%", guid, true);
         master.Replace("%%DebugExe%", GetTargetDebug(), true);
         master.Replace("%%ReleaseExe%", GetTargetRelease(), true);
         master.Replace("%%DebugExe64%", GetTargetDebug(), true);
@@ -103,22 +103,22 @@ bool CVcxWrite::CreateBuildFile()
         out.emplace_back("  </ImportGroup>");
         out.emplace_back("</Project>");
 
-        if (!out.WriteFile(cszProjVC))
+        if (!out.WriteFile(vc_project_file))
         {
-            AddError(_tt(strIdCantWrite) + cszProjVC);
+            AddError(_tt(strIdCantWrite) + vc_project_file);
             return false;
         }
         else
-            std::cout << _tt(strIdCreated) << cszProjVC << '\n';
+            std::cout << _tt(strIdCreated) << vc_project_file << '\n';
 
         master = ttlib::find_nonspace(res_vcxproj_filters_xml);
 
-        CreateGuid(cszGuid);  // it already succeeded once if we got here, so we don't check for error again
-        master.Replace("%guidSrc%", cszGuid, true);
-        CreateGuid(cszGuid);
-        master.Replace("%guidHdr%", cszGuid, true);
-        CreateGuid(cszGuid);
-        master.Replace("%guidResource%", cszGuid, true);
+        CreateGuid(guid);  // it already succeeded once if we got here, so we don't check for error again
+        master.Replace("%guidSrc%", guid, true);
+        CreateGuid(guid);
+        master.Replace("%guidHdr%", guid, true);
+        CreateGuid(guid);
+        master.Replace("%guidResource%", guid, true);
 
         out.clear();
         out.ReadString(master);
@@ -137,14 +137,14 @@ bool CVcxWrite::CreateBuildFile()
         }
         out.emplace_back("  </ItemGroup>");
         out.emplace_back("</Project>");
-        cszProjVC += ".filters";
-        if (!out.WriteFile(cszProjVC))
+        vc_project_file << ".filters";
+        if (!out.WriteFile(vc_project_file))
         {
-            AddError(_tt(strIdCantWrite) + cszProjVC);
+            AddError(_tt(strIdCantWrite) + vc_project_file);
             return false;
         }
         else
-            std::cout << _tt(strIdCreated) << cszProjVC << '\n';
+            std::cout << _tt(strIdCreated) << vc_project_file << '\n';
     }
     else
     {

--- a/src/ui/optionsdlg.cpp
+++ b/src/ui/optionsdlg.cpp
@@ -272,7 +272,7 @@ void OptionsDlg::SaveChanges()
 
 void OptionsDlg::OnAddIncDir(wxCommandEvent& WXUNUSED(event))
 {
-    wxDirDialog dlg(this, wxT("Include Directory"), m_cwd);
+    wxDirDialog dlg(this, "Include Directory", m_cwd);
     if (dlg.ShowModal() == wxID_OK)
     {
         ttString path = dlg.GetPath();
@@ -284,8 +284,8 @@ void OptionsDlg::OnAddIncDir(wxCommandEvent& WXUNUSED(event))
         if (!olddirs.contains_wx(path))
         {
             if (olddirs.size() && olddirs.Last() != ';')
-                olddirs += ';';
-            olddirs += path;
+                olddirs << ';';
+            olddirs << path;
             m_textIncludeDirs->SetValue(olddirs);
         }
     }

--- a/src/writesrc.cpp
+++ b/src/writesrc.cpp
@@ -120,19 +120,18 @@ bld::RESULT CWriteSrcFiles::UpdateOptions(std::string_view filename)
         if (option == OPT::LAST)
         {
             auto& line = out.addEmptyLine();
-            line.assign("    # unrecognized option -- ");
-            line += orgFile[pos];
+            line << "    # unrecognized option -- " << orgFile[pos];
             continue;
         }
         auto& line = out.addEmptyLine();
-        line.assign("    " + name + ":");
+        line << "    " << name << ':';
         while (line.length() < 22)
             line.push_back(' ');
-        line += getOptValue(option);
+        line << getOptValue(option);
         while (line.length() < 30)
             line.push_back(' ');
         if (getOptComment(option).size())
-            line += (" # " + getOptComment(option));
+            line << " # " << getOptComment(option);
 
         // Keep track of every option we've written out. We'll use this outside of this loop to determine what additional
         // options to write.
@@ -153,13 +152,13 @@ bld::RESULT CWriteSrcFiles::UpdateOptions(std::string_view filename)
         {
             SomethingChanged = true;
             auto& line = out.addEmptyLine();
-            line.assign("    " + getOptionName(option) + ":");
+            line << "    " << getOptionName(option) << ':';
             while (line.length() < 22)
                 line.push_back(' ');
-            line += getOptValue(option);
+            line << getOptValue(option);
             while (line.length() < 30)
                 line.push_back(' ');
-            line += (" # " + getOptComment(option));
+            line << " # " << getOptComment(option);
         }
     }
 


### PR DESCRIPTION
Closes #306

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR refactors to use the ttlib::cstr `<<` operator instead of `+=`. Because it's easier to work with, I did change the order of the cflags that get written to ninja files -- this makes the code a lot clearer as to which flags are being written out depending on debug versus release builds. That does result in all ninja scripts having a one-line change. The rest of the changes had no affect on the .ninja scripts.

I also did a bit of refactoring in the conversion files, changing some code to use c++17 design, and using `if(foo.size())` instead of `if (!foo.empty())`. In the process, I noticed a fixed a few bugs in the conversion routines related to which builds options were being read/written to -- further proof that refactoring for clarity is a good thing!