### PR TITLE
Escape use of $ in _DIRS options

### DIFF
--- a/src/cmplrMsvc.cpp
+++ b/src/cmplrMsvc.cpp
@@ -189,6 +189,7 @@ void CNinja::msvcWriteCompilerFlags(CMPLR_TYPE cmplr)
         ttlib::multistr IncDirs(getOptValue(OPT::INC_DIRS));
         for (auto dir: IncDirs)
         {
+            dir.Replace("$", "$$", true);
             // If the directory name contains a space, then place it in quotes
             if (ttlib::is_found(dir.find(' ')))
                 line << " -I\"" << dir << '\"';
@@ -290,10 +291,11 @@ void CNinja::msvcWriteLinkDirective(CMPLR_TYPE cmplr)
 
     if (hasOptValue(OPT::LIB_DIRS))
     {
-        ttlib::multiview enumLib(getOptValue(OPT::LIB_DIRS), ';');
-        for (auto iter: enumLib)
+        ttlib::multistr enumLib(getOptValue(OPT::LIB_DIRS), ';');
+        for (auto dir: enumLib)
         {
-            line << " /LIBPATH:" << iter;
+            dir.Replace("$", "$$", true);
+            line << " /LIBPATH:" << dir;
         }
     }
 
@@ -371,12 +373,13 @@ void CNinja::msvcWriteRcDirective(CMPLR_TYPE cmplr)
     if (hasOptValue(OPT::INC_DIRS))
     {
         ttlib::multistr enumDirs(getOptValue(OPT::INC_DIRS));
-        for (auto iter: enumDirs)
+        for (auto dir: enumDirs)
         {
-            if (iter.contains(" "))
-                line << " -I\"" << iter << '\"';
+            dir.Replace("$", "$$", true);
+            if (dir.contains(" "))
+                line << " -I\"" << dir << '\"';
             else
-                line << " -I" << iter;
+                line << " -I" << dir;
         }
     }
 
@@ -414,12 +417,13 @@ void CNinja::msvcWriteMidlDirective(CMPLR_TYPE /* cmplr */)
     if (hasOptValue(OPT::INC_DIRS))
     {
         ttlib::multistr enumDirs(getOptValue(OPT::INC_DIRS));
-        for (auto iter: enumDirs)
+        for (auto dir: enumDirs)
         {
-            if (iter.contains(" "))
-                line << " -I\"" << iter << '\"';
+            dir.Replace("$", "$$", true);
+            if (dir.contains(" "))
+                line << " -I\"" << dir << '\"';
             else
-                line << " -I" << iter;
+                line << " -I" << dir;
         }
     }
 


### PR DESCRIPTION
Ninja requires $ to be escaped so as not to confuse it with it's own variables.

Close #323

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This changes the output of both INC_DIRS and LIB_DIRS, replacing all occurrences of `$` with `$$`. 