### PR TITLE
Change OPT enum to enable OPT::value type

### DIFF
--- a/src/csrcfiles.h
+++ b/src/csrcfiles.h
@@ -49,44 +49,44 @@ public:
 
     // Public functions
 
-    bool isOptValue(size_t option, std::string_view value) const
+    bool isOptValue(OPT::value option, std::string_view value) const
     {
         return (getOptValue(option).is_sameas(value, tt::CASE::either));
     }
 
-    bool isOptTrue(size_t index) const
+    bool isOptTrue(OPT::value option) const
     {
-        assert(index < OPT::LAST);
-        return ttlib::is_sameas(m_Options[index].value, "true", tt::CASE::either);
+        assert(option < OPT::LAST);
+        return ttlib::is_sameas(m_Options[option].value, "true", tt::CASE::either);
     }
 
-    bool hasOptValue(size_t option) const noexcept { return (!getOptValue(option).empty()); }
+    bool hasOptValue(OPT::value option) const noexcept { return (!getOptValue(option).empty()); }
 
-    const ttlib::cstr& getOptValue(size_t index) const noexcept
+    const ttlib::cstr& getOptValue(OPT::value option) const noexcept
     {
-        assert(index < OPT::LAST);
-        return m_Options[index].value;
+        assert(option < OPT::LAST);
+        return m_Options[option].value;
     }
 
-    void setOptValue(size_t index, std::string_view value);
-    void setBoolOptValue(size_t index, bool value = true);
+    void setOptValue(OPT::value option, std::string_view value);
+    void setBoolOptValue(OPT::value option, bool value = true);
 
-    const std::string& getOptComment(size_t index) const noexcept
+    const std::string& getOptComment(OPT::value option) const noexcept
     {
-        assert(index < OPT::LAST);
-        return m_Options[index].comment;
+        assert(option < OPT::LAST);
+        return m_Options[option].comment;
     }
 
-    void setOptComment(size_t index, std::string_view value)
+    void setOptComment(OPT::value option, std::string_view value)
     {
-        assert(index < OPT::LAST);
-        m_Options[index].comment = value;
+        assert(option < OPT::LAST);
+        m_Options[option].comment = value;
     }
 
-    void SetRequired(size_t index, bool isRequired = true)
+    void SetRequired(OPT::value option, bool isRequired = true)
     {
-        assert(index < OPT::LAST);
-        m_Options[index].isRequired = isRequired;
+        assert(option < OPT::LAST);
+        m_Options[option].isRequired = isRequired;
     }
 
     const std::string& GetTargetDir();
@@ -138,26 +138,26 @@ public:
 
     void InitOptions();
 
-    bool isOptionRequired(size_t index) const
+    bool isOptionRequired(OPT::value option) const
     {
-        assert(index < OPT::LAST);
-        return m_Options[index].isRequired;
+        assert(option < OPT::LAST);
+        return m_Options[option].isRequired;
     }
 
-    std::string getOptionName(size_t index) const
+    std::string getOptionName(OPT::value option) const
     {
-        assert(index < OPT::LAST);
+        assert(option < OPT::LAST);
         std::string name;
-        name.assign(m_Options[index].OriginalName);
+        name.assign(m_Options[option].OriginalName);
         return name;
     }
 
-    bool hasOptionChanged(size_t index) const
+    bool hasOptionChanged(OPT::value option) const
     {
-        assert(index < OPT::LAST);
+        assert(option < OPT::LAST);
 
-        if (m_Options[index].value.empty() || !m_Options[index].OriginalValue ||
-            m_Options[index].value.is_sameas(m_Options[index].OriginalValue))
+        if (m_Options[option].value.empty() ||
+            (m_Options[option].OriginalValue && m_Options[option].value.is_sameas(m_Options[option].OriginalValue)))
         {
             return false;
         }
@@ -198,7 +198,7 @@ protected:
 
     ttlib::cstr m_pchCPPname;
 
-    size_t FindOption(const std::string_view name) const;
+    OPT::value FindOption(const std::string_view name) const;
 
 private:
     friend CWriteSrcFiles;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -170,22 +170,21 @@ void CSrcFiles::InitOptions()
 #endif
 }
 
-size_t CSrcFiles::FindOption(const std::string_view name) const
+OPT::value CSrcFiles::FindOption(const std::string_view name) const
 {
     assert(!name.empty());
     if (name.empty())
         return OPT::LAST;
 
-    size_t pos { 0 };
-    for (; pos < m_Options.size(); ++pos)
+    for (const auto& option: optIterator())
     {
-        if (ttlib::is_sameas(name, m_Options[pos].OriginalName, tt::CASE::either))
-            return pos;
+        if (ttlib::is_sameas(name, m_Options[option].OriginalName, tt::CASE::either))
+            return option;
     }
     return OPT::LAST;
 }
 
-void CSrcFiles::setOptValue(size_t index, std::string_view value)
+void CSrcFiles::setOptValue(OPT::value index, std::string_view value)
 {
     assert(index < OPT::LAST);
 
@@ -200,7 +199,7 @@ void CSrcFiles::setOptValue(size_t index, std::string_view value)
     }
 }
 
-void CSrcFiles::setBoolOptValue(size_t index, bool value)
+void CSrcFiles::setBoolOptValue(OPT::value index, bool value)
 {
     assert(index < OPT::LAST);
     assert(m_Options[index].isBooleanValue);

--- a/src/writesrc.cpp
+++ b/src/writesrc.cpp
@@ -142,7 +142,8 @@ bld::RESULT CWriteSrcFiles::UpdateOptions(std::string_view filename)
     // options that are required or have non-default values, they must be written here.
 
     bool SomethingChanged = false;
-    for (size_t option = 0; option < OPT::LAST; ++option)
+
+    for (const auto& option: optIterator())
     {
         // ignore if we've already written out the option
         if (std::find(orgOptions.begin(), orgOptions.end(), option) != orgOptions.end())


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes a bug in the `hasOptionChanged(...)` function that prevented some options from being updated. That specific change is intertwined with an refactoring of the OPT enum -- the enum was changed to a `OPT::value` class which made it possible to change code which was using `size_t` to access an option to `OPT::value`.

I also added an `Iterator` template class and a `typedef` that makes it possible to use a range iterator loop to step through all the options (used by the `CWriteSrcFiles::UpdateOptions()` function).

Closes #327