### PR TITLE
Add -cmake option to create a CMakeLists.txt file

### DIFF
--- a/src/.srcfiles.yaml
+++ b/src/.srcfiles.yaml
@@ -49,6 +49,7 @@ Files:
     convert/readvc.cpp        # Class for converting a Visual Studio .vcproj file to .srcfiles.yaml
     convert/readvcx.cpp       # Converts a Visual Studio project file into .srcfiles.yaml
     convert/writevcx.cpp      # Create a Visual Studio project file
+    convert/write_cmake.cpp   # Create a CMakeLists.txt file
 
     # DO NOT RUN clang-format on the following file! We need to be able to sync changes from the original repository
     pugixml/pugixml.cpp        # Built directly rather than building a library
@@ -59,9 +60,9 @@ Files:
     ui/vscodedlg.cpp           # Dialog for setting options to create tasks.json and launch.json
     ui/optionsdlg.cpp          # Dialog for setting all .srcfile options
 
-    ui/convertdlgBase.cpp      # wxUiEditor generated file
-    ui/optionsdlgBase.cpp      # wxUiEditor generated file
-    ui/vscodedlgBase.cpp       # wxUiEditor generated file
+    ui/convertdlgBase.cpp       # wxUiEditor generated file
+    ui/optionsdlgBase.cpp       # wxUiEditor generated file
+    ui/vscodedlgBase.cpp        # wxUiEditor generated file
 
     ../ttlib/src/ttconsole.cpp   # Sets/restores console foreground color
     ../ttlib/src/ttcstr.cpp      # Class for handling zero-terminated char strings.
@@ -70,6 +71,7 @@ Files:
     ../ttlib/src/ttmultistr.cpp  # Breaks a single string into multiple strings
     ../ttlib/src/ttparser.cpp    # Command line parser
     ../ttlib/src/ttstr.cpp       # ttString -- enhanced version of wxString
+    ../ttlib/src/ttsview.cpp     # std::string_view with additional methods
     ../ttlib/src/tttextfile.cpp  # Classes for reading and writing text files.
 
     ../ttlib/src/winsrc/ttregistry.cpp  # Class for working with the Windows registry

--- a/src/bld/msvc_dbg.ninja
+++ b/src/bld/msvc_dbg.ninja
@@ -86,6 +86,8 @@ build $outdir/readvcx.obj: compile convert/readvcx.cpp | $outdir/pch.obj
 
 build $outdir/writevcx.obj: compile convert/writevcx.cpp | $outdir/pch.obj
 
+build $outdir/write_cmake.obj: compile convert/write_cmake.cpp | $outdir/pch.obj
+
 build $outdir/pugixml.obj: compile pugixml/pugixml.cpp | $outdir/pch.obj
 
 build $outdir/convertdlg.obj: compile ui/convertdlg.cpp | $outdir/pch.obj
@@ -113,6 +115,8 @@ build $outdir/ttmultistr.obj: compile ../ttlib/src/ttmultistr.cpp | $outdir/pch.
 build $outdir/ttparser.obj: compile ../ttlib/src/ttparser.cpp | $outdir/pch.obj
 
 build $outdir/ttstr.obj: compile ../ttlib/src/ttstr.cpp | $outdir/pch.obj
+
+build $outdir/ttsview.obj: compile ../ttlib/src/ttsview.cpp | $outdir/pch.obj
 
 build $outdir/tttextfile.obj: compile ../ttlib/src/tttextfile.cpp | $outdir/pch.obj
 
@@ -149,6 +153,7 @@ build ../bin/ttBldD.exe : link $resout/ttBldD.res $
   $outdir/readvc.obj $
   $outdir/readvcx.obj $
   $outdir/writevcx.obj $
+  $outdir/write_cmake.obj $
   $outdir/pugixml.obj $
   $outdir/convertdlg.obj $
   $outdir/vscodedlg.obj $
@@ -163,6 +168,7 @@ build ../bin/ttBldD.exe : link $resout/ttBldD.res $
   $outdir/ttmultistr.obj $
   $outdir/ttparser.obj $
   $outdir/ttstr.obj $
+  $outdir/ttsview.obj $
   $outdir/tttextfile.obj $
   $outdir/ttregistry.obj $
   $outdir/ttdebug_min.obj $

--- a/src/bld/msvc_rel.ninja
+++ b/src/bld/msvc_rel.ninja
@@ -87,6 +87,8 @@ build $outdir/readvcx.obj: compile convert/readvcx.cpp | $outdir/pch.obj
 
 build $outdir/writevcx.obj: compile convert/writevcx.cpp | $outdir/pch.obj
 
+build $outdir/write_cmake.obj: compile convert/write_cmake.cpp | $outdir/pch.obj
+
 build $outdir/pugixml.obj: compile pugixml/pugixml.cpp | $outdir/pch.obj
 
 build $outdir/convertdlg.obj: compile ui/convertdlg.cpp | $outdir/pch.obj
@@ -114,6 +116,8 @@ build $outdir/ttmultistr.obj: compile ../ttlib/src/ttmultistr.cpp | $outdir/pch.
 build $outdir/ttparser.obj: compile ../ttlib/src/ttparser.cpp | $outdir/pch.obj
 
 build $outdir/ttstr.obj: compile ../ttlib/src/ttstr.cpp | $outdir/pch.obj
+
+build $outdir/ttsview.obj: compile ../ttlib/src/ttsview.cpp | $outdir/pch.obj
 
 build $outdir/tttextfile.obj: compile ../ttlib/src/tttextfile.cpp | $outdir/pch.obj
 
@@ -148,6 +152,7 @@ build ../bin/ttBld.exe : link $resout/ttBld.res $
   $outdir/readvc.obj $
   $outdir/readvcx.obj $
   $outdir/writevcx.obj $
+  $outdir/write_cmake.obj $
   $outdir/pugixml.obj $
   $outdir/convertdlg.obj $
   $outdir/vscodedlg.obj $
@@ -162,6 +167,7 @@ build ../bin/ttBld.exe : link $resout/ttBld.res $
   $outdir/ttmultistr.obj $
   $outdir/ttparser.obj $
   $outdir/ttstr.obj $
+  $outdir/ttsview.obj $
   $outdir/tttextfile.obj $
   $outdir/ttregistry.obj $
   $outdir/pch.obj

--- a/src/convert/write_cmake.cpp
+++ b/src/convert/write_cmake.cpp
@@ -1,0 +1,472 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Create a CMakeLists.txt file
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2020-2021 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#include "pch.h"
+
+#include "ttcwd.h"       // cwd -- Class for storing and optionally restoring the current directory
+#include "ttmultistr.h"  // multistr -- Breaks a single string into multiple strings
+#include "ttsview.h"     // sview -- std::string_view with additional methods
+#include "tttextfile.h"  // textfile -- Classes for reading and writing line-oriented files
+
+#include "csrcfiles.h"  // CSrcFiles
+
+const char* multi_config = R"===(
+get_property(isMultiConfig GLOBAL
+  PROPERTY GENERATOR_IS_MULTI_CONFIG
+)
+
+if (NOT isMultiConfig)
+    message("\nBecause you are using a single target generator, you MUST specify")
+    message("    a \"--config [Debug|Release]\" option with the cmake --build command\n")
+
+    set(allowedBuildTypes Debug Release)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "${allowedBuildTypes}")
+
+    if (NOT CMAKE_BUILD_TYPE)
+        set(CMAKE_BUILD_TYPE Debug CACHE STRING "" FORCE)
+    elseif (NOT CMAKE_BUILD_TYPE IN_LIST allowedBuildTypes)
+        message(FATAL_ERROR "Unknown build type: ${CMAKE_BUILD_TYPE}")
+    endif()
+endif()
+)===";
+
+const char* preset_json = R"===({
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 20,
+    "patch": 0
+  },
+  "configurePresets": [
+        {
+            "name": "ninja-multi",
+            "displayName": "Ninja Multi-Config",
+            "description": "Default build using Ninja Multi-Config generator",
+            "generator": "Ninja Multi-Config",
+            "binaryDir": "${sourceDir}/build"
+        }
+    ]
+}
+)===";
+
+bool CreateCmakeProject(ttlib::cstr& projectFile)
+{
+    ttlib::cwd cur_cwd;
+
+    ttlib::cstr file_prefix;
+    if (projectFile.contains("/"))
+    {
+        file_prefix = projectFile;
+        file_prefix.remove_filename();
+    }
+
+    if (file_prefix.size())
+        ttlib::ChangeDir(file_prefix);
+
+    CSrcFiles srcfiles;
+    if (!srcfiles.ReadFile(projectFile.filename()))
+    {
+        std::cout << "Cannot locate a .srcfiles.yaml to create CMakeLists.txt from!" << '\n';
+        return false;
+    }
+
+    if (file_prefix.size())
+        ttlib::ChangeDir(cur_cwd);
+
+    ttlib::textfile out;
+
+    out += "cmake_minimum_required(VERSION 3.20)";
+    out += "";
+    out.emplace_back(ttlib::cstr() << "project(" << srcfiles.GetProjectName() << " LANGUAGES CXX)");
+    out += "";
+
+    int standard = 17;
+
+    ttlib::cstr flags_cmn(srcfiles.getOptValue(OPT::CFLAGS_CMN));
+    if (srcfiles.hasOptValue(OPT::MSVC_CMN))
+    {
+        if (flags_cmn.size())
+            flags_cmn << ' ';
+        flags_cmn << srcfiles.getOptValue(OPT::MSVC_CMN);
+    }
+
+    if (flags_cmn.contains("std:c++"))
+    {
+        if (flags_cmn.contains("std:c++latest"))
+        {
+            standard = 20;
+        }
+        else
+        {
+            if (auto result = flags_cmn.find("std:c++"); ttlib::is_found(result))
+            {
+                result += 7;
+                while (!ttlib::is_digit(flags_cmn[result]) && result < flags_cmn.size())
+                    ++result;
+                if (result < flags_cmn.size())
+                    standard = flags_cmn.atoi(result);
+            }
+        }
+    }
+
+    out.emplace_back(ttlib::cstr() << "set(CMAKE_CXX_STANDARD " << standard << ")");
+    out += "set(CMAKE_CXX_STANDARD_REQUIRED True)";
+    out += "set(CMAKE_CXX_EXTENSIONS OFF)";
+    out += "";
+
+    out += "if (MSVC)";
+    out += "    # /FC	  // Full path to source code file in diagnostics";
+    out += "    string(APPEND CMAKE_CXX_FLAGS \" /FC /Zc:__cplusplus /utf-8\")";
+    out += "";
+
+    out += "    # /O1 often results in faster code than /O2 due to CPU caching";
+    out += "    string(REPLACE \"/O2\" \"/O1\" cl_optimize ${CMAKE_CXX_FLAGS_RELEASE})";
+    out += "    set(CMAKE_CXX_FLAGS_RELEASE ${cl_optimize} CACHE STRING \"C++ Release flags\" FORCE)";
+    out += "";
+
+    out += "    # Using /Z7 instead of /Zi to avoid blocking while parallel compilers write to the pdb file";
+    out += "    string(REPLACE \"/Zi\" \"/Z7\" z_seven ${CMAKE_CXX_FLAGS_DEBUG})";
+    out += "    set(CMAKE_CXX_FLAGS_DEBUG ${z_seven} CACHE STRING \"C++ Debug flags\" FORCE)";
+
+    out += "endif()";
+    out += multi_config;
+
+    bool need_blank_line { false };
+
+    if (flags_cmn.size() &&
+        (flags_cmn.contains("/D") || flags_cmn.contains("-D")))
+    {
+        need_blank_line = true;
+        ttlib::cstr flags = flags_cmn;
+        flags.Replace("-D", "/D", true, tt::CASE::exact);
+
+        ttlib::cstr definitions;
+        auto start = flags.find("/D");
+        while (ttlib::is_found(start))
+        {
+            start += 2;
+            auto end = flags.find_space(start);
+            if (!ttlib::is_found(end))
+                end = flags.size();
+            if (definitions.size())
+                definitions << ' ';
+            definitions << flags.subview(start, end - start);
+            start = flags.find("/D", end);
+        }
+
+        out.emplace_back(ttlib::cstr() << "add_compile_definitions(" << definitions << ')');
+    }
+
+    if (srcfiles.hasOptValue(OPT::CFLAGS_REL) &&
+        (srcfiles.getOptValue(OPT::CFLAGS_REL).contains("/D") || srcfiles.getOptValue(OPT::CFLAGS_REL).contains("-D")))
+    {
+        need_blank_line = true;
+        ttlib::cstr flags = srcfiles.getOptValue(OPT::CFLAGS_REL);
+        flags.Replace("-D", "/D", true, tt::CASE::exact);
+
+        ttlib::cstr definitions;
+        auto start = flags.find("/D");
+        while (ttlib::is_found(start))
+        {
+            start += 2;
+            auto end = flags.find_space(start);
+            if (!ttlib::is_found(end))
+                end = flags.size();
+            if (definitions.size())
+                definitions << ' ';
+            definitions << "$<$<CONFIG:Release>:" << flags.subview(start, end - start) << '>';
+            start = flags.find("/D", end);
+        }
+
+        out.emplace_back(ttlib::cstr() << "add_compile_definitions(" << definitions << ')');
+    }
+
+    if (srcfiles.hasOptValue(OPT::CFLAGS_DBG) &&
+        (srcfiles.getOptValue(OPT::CFLAGS_DBG).contains("/D") || srcfiles.getOptValue(OPT::CFLAGS_DBG).contains("-D")))
+    {
+        need_blank_line = true;
+        ttlib::cstr flags = srcfiles.getOptValue(OPT::CFLAGS_DBG);
+        flags.Replace("-D", "/D", true, tt::CASE::exact);
+
+        ttlib::cstr definitions;
+        auto start = flags.find("/D");
+        while (ttlib::is_found(start))
+        {
+            start += 2;
+            auto end = flags.find_space(start);
+            if (!ttlib::is_found(end))
+                end = flags.size();
+            if (definitions.size())
+                definitions << ' ';
+            definitions << "$<$<CONFIG:Debug>:" << flags.subview(start, end - start) << '>';
+            start = flags.find("/D", end);
+        }
+
+        out.emplace_back(ttlib::cstr() << "add_compile_definitions(" << definitions << ')');
+    }
+
+    if (need_blank_line)
+    {
+        out += "";
+        need_blank_line = false;
+    }
+
+    out += "if (MSVC)";
+    out += "    # /GL is combined with the Linker flag /LTCG to perform whole program optimization";
+    out += "    add_compile_options(\"$<$<CONFIG:Release>:/GL>\")";
+    out += "    add_link_options($<$<CONFIG:Release>:LTCG>)";
+
+    if (srcfiles.hasOptValue(OPT::NATVIS))
+    {
+        // The natvis file is relative to the build directory which is parellel to any src directoyr
+        out.emplace_back(
+            ttlib::cstr() << "    add_link_options($<$<CONFIG:Debug>:/natvis:" << srcfiles.getOptValue(OPT::NATVIS) << ">)");
+    }
+
+    if (srcfiles.getRcName().size())
+    {
+        out += "\n    # Assume the manifest is in the resource file";
+        out += "    add_link_options(/manifest:no)";
+    }
+
+    out += "endif()";
+    out += "";
+
+    if (srcfiles.GetDebugFileList().size())
+    {
+        out += "# Note the requirement that --config Debug is used to get the additional debug files";
+    }
+
+    ttlib::viewfile in;
+    if (!in.ReadFile(projectFile))
+    {
+        std::cout << "Unable to read " << srcfiles.GetSrcFilesName() << '\n';
+        return false;
+    }
+
+    auto file_pos = in.FindLineContaining("Files:");
+    if (!ttlib::is_found(file_pos))
+    {
+        std::cout << srcfiles.GetSrcFilesName() << " does not contain a Files: section" << '\n';
+        return false;
+    }
+
+    out.emplace_back(ttlib::cstr() << "add_executable(" << srcfiles.GetProjectName());
+    if (srcfiles.IsExeTypeWindow())
+    {
+        out.back() << " WIN32";
+    }
+
+    for (++file_pos; file_pos < in.size(); ++file_pos)
+    {
+        if (in[file_pos].empty())
+        {
+            out += "";
+            continue;
+        }
+
+        if (ttlib::is_alpha(in[file_pos].front()))
+        {
+            // Alphabetic character in first position starts a new session
+            break;
+        }
+
+        ttlib::sview view(in[file_pos]);
+        view.moveto_nonspace();
+        if (view.front() == '#')
+        {
+            out += in[file_pos];
+            continue;
+        }
+
+        if (file_prefix.size())
+        {
+            ttlib::cstr path;
+            ttlib::cstr non_relative;
+            non_relative << file_prefix << "../";
+            path << file_prefix << ttlib::find_nonspace(in[file_pos]);
+            if (path.is_sameprefix(non_relative))
+            {
+                path.erase(0, non_relative.size());
+            }
+            out.emplace_back(ttlib::cstr() << "    " << path);
+        }
+        else
+        {
+            out += in[file_pos];
+        }
+    }
+
+    if (file_pos = in.FindLineContaining("DebugFiles:"); ttlib::is_found(file_pos))
+    {
+        for (++file_pos; file_pos < in.size(); ++file_pos)
+        {
+            if (in[file_pos].empty())
+            {
+                out += "";
+                continue;
+            }
+
+            if (ttlib::is_alpha(in[file_pos].front()))
+            {
+                // Alphabetic character in first position starts a new session
+                break;
+            }
+
+            ttlib::sview view(in[file_pos]);
+            view.moveto_nonspace();
+            if (view.front() == '#')
+            {
+                out += in[file_pos];
+                continue;
+            }
+
+            ttlib::cstr path;
+            path << file_prefix << ttlib::find_nonspace(in[file_pos]);
+            if (file_prefix.size())
+            {
+                ttlib::cstr non_relative;
+                non_relative << file_prefix << "../";
+                if (path.is_sameprefix(non_relative))
+                {
+                    path.erase(0, non_relative.size());
+                }
+            }
+            if (auto result = path.find('#'); ttlib::is_found(result))
+            {
+                ttlib::cstr comment = path.substr(result);
+                path.erase(result);
+                path.RightTrim();
+                path << '>' << "  " << comment;
+                out.emplace_back(ttlib::cstr() << "    $<$<CONFIG:Debug>:" << path);
+            }
+            else
+            {
+                out.emplace_back(ttlib::cstr() << "    $<$<CONFIG:Debug>:" << path << '>');
+            }
+        }
+    }
+
+    out += ")";
+    out += "";
+
+    if (srcfiles.HasPch())
+    {
+        ttlib::cstr pch_path;
+        if (file_prefix.size())
+            pch_path = file_prefix;
+        pch_path << srcfiles.getOptValue(OPT::PCH);
+        out.emplace_back(ttlib::cstr() << "target_precompile_headers(" << srcfiles.GetProjectName() << " PRIVATE "
+                                       << pch_path << ")");
+        out += "";
+    }
+
+    if (srcfiles.hasOptValue(OPT::INC_DIRS))
+    {
+        out.emplace_back(ttlib::cstr() << "target_include_directories(" << srcfiles.GetProjectName() << " PRIVATE ");
+
+        ttlib::multiview inc_list(srcfiles.getOptValue(OPT::INC_DIRS));
+        for (auto& iter: inc_list)
+        {
+            ttlib::cstr inc_path("    ");
+            if (iter.front() == '$')
+            {
+                auto end = iter.find(')');
+                inc_path << "$ENV{" << iter.substr(2, end - 2) << '}' << iter.subview(end + 1);
+                out.emplace_back(inc_path);
+                continue;
+            }
+            if (file_prefix.size())
+                inc_path << file_prefix;
+            if (!iter.is_sameas("./"))
+                inc_path << iter;
+
+            out.emplace_back(inc_path);
+        }
+        out += ")";
+        out += "";
+    }
+
+    if (srcfiles.hasOptValue(OPT::LIB_DIRS) || srcfiles.hasOptValue(OPT::LIB_DIRS64))
+        out += "if (MSVC)";
+
+    if (srcfiles.hasOptValue(OPT::LIB_DIRS))
+    {
+        out.emplace_back(ttlib::cstr() << "    target_link_directories(" << srcfiles.GetProjectName() << " PRIVATE ");
+
+        ttlib::multiview lib_list(srcfiles.getOptValue(OPT::LIB_DIRS));
+        for (auto& iter: lib_list)
+        {
+            ttlib::cstr lib_path("        ");
+            if (iter.front() == '$')
+            {
+                auto end = iter.find(')');
+                lib_path << "$ENV{" << iter.substr(2, end - 2) << '}' << iter.subview(end + 1);
+                out.emplace_back(lib_path);
+                continue;
+            }
+
+            if (file_prefix.size() && iter.front() == '.')
+                lib_path << file_prefix;
+            lib_path << iter;
+
+            out.emplace_back(lib_path);
+        }
+        out += "    )";
+    }
+    else if (srcfiles.hasOptValue(OPT::LIB_DIRS64))
+    {
+        out.emplace_back(ttlib::cstr() << "    target_link_directories(" << srcfiles.GetProjectName() << " PRIVATE ");
+
+        ttlib::multiview lib_list(srcfiles.getOptValue(OPT::LIB_DIRS64));
+        for (auto& iter: lib_list)
+        {
+            ttlib::cstr lib_path("        ");
+            if (iter.front() == '$')
+            {
+                auto end = iter.find(')');
+                lib_path << "$ENV{" << iter.substr(2, end - 2) << '}' << iter.subview(end + 1);
+                out.emplace_back(lib_path);
+                continue;
+            }
+
+            if (file_prefix.size() && iter.front() == '.')
+                lib_path << file_prefix;
+            lib_path << iter;
+
+            out.emplace_back(lib_path);
+        }
+        out += "    )";
+    }
+    if (srcfiles.hasOptValue(OPT::LIB_DIRS) || srcfiles.hasOptValue(OPT::LIB_DIRS64))
+        out += "endif()";
+
+    ttlib::cstr out_name("CMakeLists.txt");
+    if (ttlib::file_exists(out_name))
+    {
+        out_name.replace_extension(".ttbld");
+    }
+
+    if (!out.WriteFile(out_name))
+    {
+        std::cout << "Cannot write to " << out_name << '\n';
+        return false;
+    }
+
+    std::cout << "Created " << out_name << '\n';
+    if (!ttlib::file_exists("CMakePresets.json"))
+    {
+        out.clear();
+        out.ReadString(preset_json);
+        if (out.WriteFile("CMakePresets.json"))
+        {
+            std::cout << "Created CMakePresets.json" << '\n';
+        }
+    }
+
+    return true;
+}

--- a/src/csrcfiles.h
+++ b/src/csrcfiles.h
@@ -131,6 +131,7 @@ public:
     const auto& getErrorMsgs() { return m_lstErrMessages; }
 
     auto& GetSrcFileList() { return m_lstSrcFiles; }
+    auto& GetDebugFileList() { return m_lstDebugFiles; }
 
     void SetReportingFile(std::string_view filename) { m_ReportPath = filename; }
 

--- a/src/funcs.h
+++ b/src/funcs.h
@@ -48,6 +48,9 @@ bool CreateMSVCEnvCmd(const char* pszDstFile, bool bDef64 = false);
 bool FindCurMsvcPath(ttlib::cstr& Result);
 bool FindVsCode(ttlib::cstr& Result);
 
+// Called to create a cmake project (creates CMakeLists.txt)
+bool CreateCmakeProject(ttlib::cstr& projectFile);
+
 // Called when ttBld is run and there is no project, or -new is specified.
 bool MakeNewProject(ttlib::cstr& projectFile);
 

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -129,6 +129,7 @@ int CMainApp::OnRun()
     cmd.addOption("force", "create .ninja file(s) even if nothing has changed");
     cmd.addOption("makefile", "creates a makefile that doesn't require ttBld.exe");
 
+    cmd.addOption("cmake", "Uses .srcfiles.yaml as a template to create a cmake CMakeLists.txt file");
     cmd.addOption("vscode", "creates or updates .vscode/*.json files used to build and debug a project using VS Code");
     cmd.addOption("vcxproj", "creates or updates Visual Studio project file (.vcxproj)");
     cmd.addOption("vs", "adds or updates .vs/*.json files used by Visual Studio");
@@ -318,6 +319,15 @@ int CMainApp::OnRun()
         return 0;
     }
 
+    if (cmd.isOption("cmake"))
+    {
+        if (projectFile.empty())
+        {
+            projectFile.assign(locateProjectFile(RootDir));
+        }
+        return (CreateCmakeProject(projectFile) ? 0 : 1);
+    }
+
     // If a project file gets created, the options and vscode have already been set, and this flag will have been set to
     // true.
     bool projectCreated = false;
@@ -465,7 +475,7 @@ int CMainApp::OnRun()
                   << " files" << '\n';
 #if defined(_DEBUG)
         ttlib::cstr msg(ttlib::cstr("Created ") << countNinjas << " .ninja"
-                                           << " files" << '\n');
+                                                << " files" << '\n');
         wxLogDebug(msg.to_utf16().c_str());
 #endif  // _DEBUG
     }

--- a/src/ui/convertdlgBase.cpp
+++ b/src/ui/convertdlgBase.cpp
@@ -16,10 +16,11 @@
 
 #include "convertdlgBase.h"
 
-ConvertDlgBase::ConvertDlgBase(wxWindow* parent) : wxDialog()
+bool ConvertDlgBase::Create(wxWindow *parent, wxWindowID id, const wxString &title,
+        const wxPoint&pos, const wxSize& size, long style, const wxString &name)
 {
-    Create(parent, wxID_ANY, wxString::FromUTF8("Create new .srcfiles.yaml file"), wxDefaultPosition, wxDefaultSize,
-        wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER);
+    if (!wxDialog::Create(parent, id, title, pos, size, style, name))
+        return false;
 
     auto parent_sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -90,4 +91,6 @@ ConvertDlgBase::ConvertDlgBase(wxWindow* parent) : wxDialog()
     Bind(wxEVT_INIT_DIALOG, &ConvertDlgBase::OnInit, this);
     m_filePickerProject->Bind(wxEVT_FILEPICKER_CHANGED, &ConvertDlgBase::OnProjectFileLocated, this);
     Bind(wxEVT_BUTTON, &ConvertDlgBase::OnOK, this, wxID_OK);
+
+    return true;
 }

--- a/src/ui/convertdlgBase.h
+++ b/src/ui/convertdlgBase.h
@@ -17,7 +17,17 @@
 class ConvertDlgBase : public wxDialog
 {
 public:
-    ConvertDlgBase(wxWindow* parent);
+    ConvertDlgBase() {}
+    ConvertDlgBase(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Create new .srcfiles.yaml file"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER, const wxString &name = wxDialogNameStr)
+    {
+        Create(parent, id, title, pos, size, style, name);
+    }
+
+    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Create new .srcfiles.yaml file"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER, const wxString &name = wxDialogNameStr);
 
     bool isCreateVsCode() const { return m_AddVscodeDir; }
     bool isAddToGitExclude() const { return m_gitIgnore; }

--- a/src/ui/optionsdlgBase.cpp
+++ b/src/ui/optionsdlgBase.cpp
@@ -22,10 +22,11 @@
 
 #include "optionsdlgBase.h"
 
-OptionsDlgBase::OptionsDlgBase(wxWindow* parent) : wxDialog()
+bool OptionsDlgBase::Create(wxWindow *parent, wxWindowID id, const wxString &title,
+        const wxPoint&pos, const wxSize& size, long style, const wxString &name)
 {
-    Create(parent, wxID_ANY, wxString::FromUTF8("Options for .srcfiles"), wxDefaultPosition, wxDefaultSize,
-        wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER);
+    if (!wxDialog::Create(parent, id, title, pos, size, style, name))
+        return false;
 
     auto parent_sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -113,8 +114,7 @@ OptionsDlgBase::OptionsDlgBase(wxWindow* parent) : wxDialog()
     auto staticText3 = new wxStaticText(panel, wxID_ANY, wxString::FromUTF8("&Warning level:"));
     box_sizer4->Add(staticText3, wxSizerFlags().Center().Border(wxALL));
 
-    auto spinCtrl = new wxSpinCtrl(panel, wxID_ANY, wxEmptyString,
-    wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 4, 4);
+    auto spinCtrl = new wxSpinCtrl(panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 4, 4);
     spinCtrl->SetValidator(wxGenericValidator(&m_WarningLevel));
     box_sizer4->Add(spinCtrl, wxSizerFlags().Border(wxALL));
 
@@ -473,4 +473,6 @@ OptionsDlgBase::OptionsDlgBase(wxWindow* parent) : wxDialog()
     btnAddReleaseLibraries->Bind(wxEVT_BUTTON, &OptionsDlgBase::OnAddReleaseLibraries, this);
     btnAddDebugLibraries->Bind(wxEVT_BUTTON, &OptionsDlgBase::OnAddDebugLibraries, this);
     btnAddBuildLibraries->Bind(wxEVT_BUTTON, &OptionsDlgBase::OnAddBuildLibraries, this);
+
+    return true;
 }

--- a/src/ui/optionsdlgBase.h
+++ b/src/ui/optionsdlgBase.h
@@ -17,7 +17,17 @@
 class OptionsDlgBase : public wxDialog
 {
 public:
-    OptionsDlgBase(wxWindow* parent);
+    OptionsDlgBase() {}
+    OptionsDlgBase(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Options for .srcfiles"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER, const wxString &name = wxDialogNameStr)
+    {
+        Create(parent, id, title, pos, size, style, name);
+    }
+
+    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Options for .srcfiles"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER, const wxString &name = wxDialogNameStr);
 
 protected:
 

--- a/src/ui/ttBld.wxui
+++ b/src/ui/ttBld.wxui
@@ -1,220 +1,922 @@
 <?xml version="1.0"?>
-<wxUiEditorData data_version="11">
-  <node class="Project" local_pch_file="pch.h">
-    <node class="wxDialog" base_file="vscodedlgBase" class_name="VsCodeDlgBase" derived_class_name="VsCodeDlg" title="Create .vscode files" wxEVT_INIT_DIALOG="OnInit">
-      <node class="wxBoxSizer" orientation="wxVERTICAL" var_name="parent_sizer">
-        <node class="wxBoxSizer" flags="wxEXPAND">
-          <node class="wxStaticBoxSizer" label="tasks.json" flags="wxEXPAND">
-            <node class="wxCheckBox" label="MSVC builds" validator_variable="m_taskMSVCBuild" />
-            <node class="wxCheckBox" label="CLANG builds" var_name="m_checkBox2" validator_variable="m_taskCLANGBuild" />
-            <node class="wxCheckBox" checked="true" label="Ninja debug build" var_name="m_checkBox3" validator_variable="m_taskNinjaBuild" />
+<wxUiEditorData
+  data_version="12">
+  <node
+    class="Project"
+    local_pch_file="pch.h">
+    <node
+      class="wxDialog"
+      base_file="vscodedlgBase"
+      class_name="VsCodeDlgBase"
+      derived_class_name="VsCodeDlg"
+      title="Create .vscode files"
+      wxEVT_INIT_DIALOG="OnInit">
+      <node
+        class="wxBoxSizer"
+        orientation="wxVERTICAL"
+        var_name="parent_sizer">
+        <node
+          class="wxBoxSizer"
+          flags="wxEXPAND">
+          <node
+            class="wxStaticBoxSizer"
+            label="tasks.json"
+            flags="wxEXPAND">
+            <node
+              class="wxCheckBox"
+              label="MSVC builds"
+              validator_variable="m_taskMSVCBuild" />
+            <node
+              class="wxCheckBox"
+              label="CLANG builds"
+              var_name="m_checkBox2"
+              validator_variable="m_taskCLANGBuild" />
+            <node
+              class="wxCheckBox"
+              checked="true"
+              label="Ninja debug build"
+              var_name="m_checkBox3"
+              validator_variable="m_taskNinjaBuild" />
           </node>
-          <node class="wxStaticBoxSizer" label="Default task" var_name="static_box_sizer2" flags="wxEXPAND">
-            <node class="wxRadioButton" label="MSVC debug" style="wxRB_GROUP" validator_variable="m_defTaskMSVC" />
-            <node class="wxRadioButton" label="CLANG debug" var_name="m_radioBtn2" validator_variable="m_defTaskCLANG" />
-            <node class="wxRadioButton" checked="true" label="Ninja debug" var_name="m_radioBtn3" validator_variable="m_defTaskNinja" />
+          <node
+            class="wxStaticBoxSizer"
+            label="Default task"
+            var_name="static_box_sizer2"
+            flags="wxEXPAND">
+            <node
+              class="wxRadioButton"
+              label="MSVC debug"
+              style="wxRB_GROUP"
+              validator_variable="m_defTaskMSVC" />
+            <node
+              class="wxRadioButton"
+              label="CLANG debug"
+              var_name="m_radioBtn2"
+              validator_variable="m_defTaskCLANG" />
+            <node
+              class="wxRadioButton"
+              checked="true"
+              label="Ninja debug"
+              var_name="m_radioBtn3"
+              validator_variable="m_defTaskNinja" />
           </node>
         </node>
-        <node class="wxBoxSizer" var_name="box_sizer2" flags="wxEXPAND">
-          <node class="wxStaticBoxSizer" label="launch.json Pre-launch build" var_name="static_box_sizer3" flags="wxEXPAND" proportion="1">
-            <node class="wxRadioButton" label="none" style="wxRB_GROUP" var_name="m_radioBtn4" validator_variable="m_preLaunchNone" />
-            <node class="wxRadioButton" label="MSVC debug" var_name="m_radioBtn5" validator_variable="m_preLaunchMSVC" />
-            <node class="wxRadioButton" label="CLANG debug" var_name="m_radioBtn6" validator_variable="m_preLaunchCLANG" />
-            <node class="wxRadioButton" checked="true" label="Ninja debug" var_name="m_radioBtn7" validator_variable="m_preLaunchNinja" />
+        <node
+          class="wxBoxSizer"
+          var_name="box_sizer2"
+          flags="wxEXPAND">
+          <node
+            class="wxStaticBoxSizer"
+            label="launch.json Pre-launch build"
+            var_name="static_box_sizer3"
+            flags="wxEXPAND"
+            proportion="1">
+            <node
+              class="wxRadioButton"
+              label="none"
+              style="wxRB_GROUP"
+              var_name="m_radioBtn4"
+              validator_variable="m_preLaunchNone" />
+            <node
+              class="wxRadioButton"
+              label="MSVC debug"
+              var_name="m_radioBtn5"
+              validator_variable="m_preLaunchMSVC" />
+            <node
+              class="wxRadioButton"
+              label="CLANG debug"
+              var_name="m_radioBtn6"
+              validator_variable="m_preLaunchCLANG" />
+            <node
+              class="wxRadioButton"
+              checked="true"
+              label="Ninja debug"
+              var_name="m_radioBtn7"
+              validator_variable="m_preLaunchNinja" />
           </node>
         </node>
-        <node class="wxStdDialogButtonSizer" flags="wxEXPAND" />
+        <node
+          class="wxStdDialogButtonSizer"
+          flags="wxEXPAND" />
       </node>
     </node>
-    <node class="wxDialog" base_file="convertdlgBase" class_name="ConvertDlgBase" derived_class_name="ConvertDlg" persist="true" style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER" title="Create new .srcfiles.yaml file" wxEVT_INIT_DIALOG="OnInit">
-      <node class="wxBoxSizer" orientation="wxVERTICAL" var_name="parent_sizer">
-        <node class="wxBoxSizer" orientation="wxVERTICAL" flags="wxEXPAND">
-          <node class="wxStaticText" class_access="none" label="C&amp;reate .srcfiles.yaml in:" var_name="staticText" borders="wxLEFT|wxRIGHT|wxTOP" />
-          <node class="wxDirPickerCtrl" var_name="m_dirPickerOut" flags="wxEXPAND" />
+    <node
+      class="wxDialog"
+      base_file="convertdlgBase"
+      class_name="ConvertDlgBase"
+      derived_class_name="ConvertDlg"
+      persist="true"
+      style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
+      title="Create new .srcfiles.yaml file"
+      wxEVT_INIT_DIALOG="OnInit">
+      <node
+        class="wxBoxSizer"
+        orientation="wxVERTICAL"
+        var_name="parent_sizer">
+        <node
+          class="wxBoxSizer"
+          orientation="wxVERTICAL"
+          flags="wxEXPAND">
+          <node
+            class="wxStaticText"
+            class_access="none"
+            label="C&amp;reate .srcfiles.yaml in:"
+            var_name="staticText"
+            borders="wxLEFT|wxRIGHT|wxTOP" />
+          <node
+            class="wxDirPickerCtrl"
+            var_name="m_dirPickerOut"
+            flags="wxEXPAND" />
         </node>
-        <node class="wxBoxSizer" orientation="wxVERTICAL" var_name="box_sizer2" flags="wxEXPAND">
-          <node class="wxRadioButton" label="Create using all files in:" style="wxRB_GROUP" validator_variable="m_useAllFiles" borders="wxLEFT|wxRIGHT|wxTOP" />
-          <node class="wxDirPickerCtrl" var_name="m_dirPickerList" flags="wxEXPAND" />
+        <node
+          class="wxBoxSizer"
+          orientation="wxVERTICAL"
+          var_name="box_sizer2"
+          flags="wxEXPAND">
+          <node
+            class="wxRadioButton"
+            label="Create using all files in:"
+            style="wxRB_GROUP"
+            validator_variable="m_useAllFiles"
+            borders="wxLEFT|wxRIGHT|wxTOP" />
+          <node
+            class="wxDirPickerCtrl"
+            var_name="m_dirPickerList"
+            flags="wxEXPAND" />
         </node>
-        <node class="wxBoxSizer" orientation="wxVERTICAL" var_name="box_sizer3" flags="wxEXPAND">
-          <node class="wxRadioButton" label="Create using &amp;project file:" var_name="m_radioBtn2" validator_variable="m_useProjectFile" borders="wxLEFT|wxRIGHT|wxTOP" />
-          <node class="wxBoxSizer" var_name="box_sizer4" borders="wxBOTTOM" flags="wxEXPAND">
-            <node class="wxChoice" var_name="m_choiceProjects" validator_variable="m_Project" borders="wxLEFT|wxRIGHT|wxTOP" proportion="1" />
-            <node class="wxFilePickerCtrl" style="wxFLP_FILE_MUST_EXIST|wxFLP_OPEN" var_name="m_filePickerProject" wildcard="Project Files|*.vcxproj;*.vcproj;*.project;*.cbp;*.dsp" wxEVT_FILEPICKER_CHANGED="OnProjectFileLocated" />
+        <node
+          class="wxBoxSizer"
+          orientation="wxVERTICAL"
+          var_name="box_sizer3"
+          flags="wxEXPAND">
+          <node
+            class="wxRadioButton"
+            label="Create using &amp;project file:"
+            var_name="m_radioBtn2"
+            validator_variable="m_useProjectFile"
+            borders="wxLEFT|wxRIGHT|wxTOP" />
+          <node
+            class="wxBoxSizer"
+            var_name="box_sizer4"
+            borders="wxBOTTOM"
+            flags="wxEXPAND">
+            <node
+              class="wxChoice"
+              var_name="m_choiceProjects"
+              validator_variable="m_Project"
+              borders="wxLEFT|wxRIGHT|wxTOP"
+              proportion="1" />
+            <node
+              class="wxFilePickerCtrl"
+              style="wxFLP_FILE_MUST_EXIST|wxFLP_OPEN"
+              var_name="m_filePickerProject"
+              wildcard="Project Files|*.vcxproj;*.vcproj;*.project;*.cbp;*.dsp"
+              wxEVT_FILEPICKER_CHANGED="OnProjectFileLocated" />
           </node>
         </node>
-        <node class="wxBoxSizer" orientation="wxVERTICAL" var_name="box_sizer5" flags="wxEXPAND">
-          <node class="wxCheckBox" label="&amp;Add .vscode/ directory and files (tasks.json, launch.json, etc.)" get_function="isCreateVsCode" validator_variable="m_AddVscodeDir" tooltip="If checked, files are added to a .vscode/ directory so that you can build the project from with Visual Studio Code." />
-          <node class="wxCheckBox" label="Have &amp;git ignore all generated files and directories" var_name="m_checkGitIgnore" get_function="isAddToGitExclude" validator_variable="m_gitIgnore" tooltip="If checked, all ttBld generated file types and directories will be added to .git/info/exclude so that they will not be tracked." />
+        <node
+          class="wxBoxSizer"
+          orientation="wxVERTICAL"
+          var_name="box_sizer5"
+          flags="wxEXPAND">
+          <node
+            class="wxCheckBox"
+            label="&amp;Add .vscode/ directory and files (tasks.json, launch.json, etc.)"
+            get_function="isCreateVsCode"
+            validator_variable="m_AddVscodeDir"
+            tooltip="If checked, files are added to a .vscode/ directory so that you can build the project from with Visual Studio Code." />
+          <node
+            class="wxCheckBox"
+            label="Have &amp;git ignore all generated files and directories"
+            var_name="m_checkGitIgnore"
+            get_function="isAddToGitExclude"
+            validator_variable="m_gitIgnore"
+            tooltip="If checked, all ttBld generated file types and directories will be added to .git/info/exclude so that they will not be tracked." />
         </node>
-        <node class="wxStaticLine" border_size="8" flags="wxEXPAND" />
-        <node class="wxStdDialogButtonSizer" flags="wxEXPAND" OKButtonClicked="OnOK" />
+        <node
+          class="wxStaticLine"
+          border_size="8"
+          flags="wxEXPAND" />
+        <node
+          class="wxStdDialogButtonSizer"
+          flags="wxEXPAND"
+          OKButtonClicked="OnOK" />
       </node>
     </node>
-    <node class="wxDialog" base_file="optionsdlgBase" class_name="OptionsDlgBase" derived_class_name="OptionsDlg" persist="true" style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER" title="Options for .srcfiles">
-      <node class="wxBoxSizer" orientation="wxVERTICAL" var_name="parent_sizer">
-        <node class="wxNotebook" minimum_size="370,-1" flags="wxEXPAND" proportion="1">
-          <node class="BookPage" label="General" select="true" background_colour="wxSYS_COLOUR_BTNFACE" window_style="wxTAB_TRAVERSAL">
-            <node class="wxBoxSizer" orientation="wxVERTICAL" var_name="parent_sizer2">
-              <node class="wxBoxSizer" flags="wxEXPAND">
-                <node class="wxStaticText" label="&amp;Project Name:" alignment="wxALIGN_CENTER" />
-                <node class="wxTextCtrl" class_access="none" var_name="textCtrl" validator_variable="m_ProjectName" proportion="1" />
+    <node
+      class="wxDialog"
+      base_file="optionsdlgBase"
+      class_name="OptionsDlgBase"
+      derived_class_name="OptionsDlg"
+      persist="true"
+      style="wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER"
+      title="Options for .srcfiles">
+      <node
+        class="wxBoxSizer"
+        orientation="wxVERTICAL"
+        var_name="parent_sizer">
+        <node
+          class="wxNotebook"
+          minimum_size="370,-1"
+          flags="wxEXPAND"
+          proportion="1">
+          <node
+            class="BookPage"
+            label="General"
+            select="true"
+            background_colour="wxSYS_COLOUR_BTNFACE"
+            window_style="wxTAB_TRAVERSAL">
+            <node
+              class="wxBoxSizer"
+              orientation="wxVERTICAL"
+              var_name="parent_sizer2">
+              <node
+                class="wxBoxSizer"
+                flags="wxEXPAND">
+                <node
+                  class="wxStaticText"
+                  label="&amp;Project Name:"
+                  alignment="wxALIGN_CENTER" />
+                <node
+                  class="wxTextCtrl"
+                  class_access="none"
+                  var_name="textCtrl"
+                  validator_variable="m_ProjectName"
+                  proportion="1" />
               </node>
-              <node class="wxStaticBoxSizer" class_access="none" label="Project Type" flags="wxEXPAND">
-                <node class="wxFlexGridSizer" cols="3" var_name="flex_grid_sizer6" flags="wxEXPAND">
-                  <node class="wxRadioButton" class_access="none" label="Window" var_name="radioBtn" validator_variable="m_isWindow" />
-                  <node class="wxRadioButton" class_access="none" label="Console" var_name="radioBtn2" validator_variable="m_isConsole" />
-                  <node class="wxRadioButton" class_access="none" label="Library" var_name="radioBtn3" validator_variable="m_isLibrary" />
-                  <node class="wxRadioButton" class_access="none" label="DLL" var_name="radioBtn4" validator_variable="m_isDll" />
-                  <node class="wxRadioButton" class_access="none" label="OCX" var_name="radioBtn_5" validator_variable="m_isOcx" />
+              <node
+                class="wxStaticBoxSizer"
+                label="Project Type"
+                flags="wxEXPAND">
+                <node
+                  class="wxFlexGridSizer"
+                  cols="3"
+                  var_name="flex_grid_sizer6"
+                  flags="wxEXPAND">
+                  <node
+                    class="wxRadioButton"
+                    class_access="none"
+                    label="Window"
+                    var_name="radioBtn"
+                    validator_variable="m_isWindow" />
+                  <node
+                    class="wxRadioButton"
+                    class_access="none"
+                    label="Console"
+                    var_name="radioBtn2"
+                    validator_variable="m_isConsole" />
+                  <node
+                    class="wxRadioButton"
+                    class_access="none"
+                    label="Library"
+                    var_name="radioBtn3"
+                    validator_variable="m_isLibrary" />
+                  <node
+                    class="wxRadioButton"
+                    class_access="none"
+                    label="DLL"
+                    var_name="radioBtn4"
+                    validator_variable="m_isDll" />
+                  <node
+                    class="wxRadioButton"
+                    class_access="none"
+                    label="OCX"
+                    var_name="radioBtn_5"
+                    validator_variable="m_isOcx" />
                 </node>
               </node>
-              <node class="wxBoxSizer" orientation="wxVERTICAL" var_name="box_sizer2" flags="wxEXPAND">
-                <node class="wxStaticText" class_access="none" label="&amp;Target Directory" var_name="staticText" />
-                <node class="wxDirPickerCtrl" var_name="m_TargetDirPicker" flags="wxEXPAND" wxEVT_DIRPICKER_CHANGED="OnTargetDirChanged" />
+              <node
+                class="wxBoxSizer"
+                orientation="wxVERTICAL"
+                var_name="box_sizer2"
+                flags="wxEXPAND">
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;Target Directory"
+                  var_name="staticText" />
+                <node
+                  class="wxDirPickerCtrl"
+                  var_name="m_TargetDirPicker"
+                  flags="wxEXPAND"
+                  wxEVT_DIRPICKER_CHANGED="OnTargetDirChanged" />
               </node>
             </node>
           </node>
-          <node class="BookPage" label="Compiler" var_name="panel" background_colour="wxSYS_COLOUR_BTNFACE" window_style="wxTAB_TRAVERSAL">
-            <node class="wxBoxSizer" orientation="wxVERTICAL" var_name="parent_sizer3">
-              <node class="wxBoxSizer" var_name="box_sizer3" flags="wxEXPAND">
-                <node class="wxStaticText" class_access="none" label="&amp;Optimize for" var_name="staticText2" />
-                <node class="wxRadioButton" checked="true" class_access="none" label="Space" style="wxRB_GROUP" var_name="radioBtn5" validator_variable="m_isSpaceOptimization" />
-                <node class="wxRadioButton" class_access="none" label="Speed" var_name="radioBtn6" validator_variable="m_isSpeedOptimization" />
+          <node
+            class="BookPage"
+            label="Compiler"
+            var_name="panel"
+            background_colour="wxSYS_COLOUR_BTNFACE"
+            window_style="wxTAB_TRAVERSAL">
+            <node
+              class="wxBoxSizer"
+              orientation="wxVERTICAL"
+              var_name="parent_sizer3">
+              <node
+                class="wxBoxSizer"
+                var_name="box_sizer3"
+                flags="wxEXPAND">
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;Optimize for"
+                  var_name="staticText2" />
+                <node
+                  class="wxRadioButton"
+                  checked="true"
+                  class_access="none"
+                  label="Space"
+                  style="wxRB_GROUP"
+                  var_name="radioBtn5"
+                  validator_variable="m_isSpaceOptimization" />
+                <node
+                  class="wxRadioButton"
+                  class_access="none"
+                  label="Speed"
+                  var_name="radioBtn6"
+                  validator_variable="m_isSpeedOptimization" />
               </node>
-              <node class="wxBoxSizer" var_name="box_sizer4" flags="wxEXPAND">
-                <node class="wxStaticText" class_access="none" label="&amp;Warning level:" var_name="staticText3" alignment="wxALIGN_CENTER" />
-                <node class="wxSpinCtrl" class_access="none" initial="4" max="4" min="1" var_name="spinCtrl" validator_variable="m_WarningLevel" />
+              <node
+                class="wxBoxSizer"
+                var_name="box_sizer4"
+                flags="wxEXPAND">
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;Warning level:"
+                  var_name="staticText3"
+                  alignment="wxALIGN_CENTER" />
+                <node
+                  class="wxSpinCtrl"
+                  class_access="none"
+                  initial="4"
+                  max="4"
+                  min="1"
+                  var_name="spinCtrl"
+                  validator_variable="m_WarningLevel" />
               </node>
-              <node class="wxBoxSizer" var_name="box_sizer5" flags="wxEXPAND">
-                <node class="wxStaticText" class_access="none" label="PCH &amp;Header:" var_name="staticText4" alignment="wxALIGN_CENTER" />
-                <node class="wxFilePickerCtrl" style="wxFLP_FILE_MUST_EXIST|wxFLP_OPEN|wxFLP_USE_TEXTCTRL" var_name="m_PchHeaderPicker" wildcard="Header files|*.h;*.hh;*.hpp;*.hxx" wxEVT_FILEPICKER_CHANGED="OnPchHeaderChanged" />
+              <node
+                class="wxBoxSizer"
+                var_name="box_sizer5"
+                flags="wxEXPAND">
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="PCH &amp;Header:"
+                  var_name="staticText4"
+                  alignment="wxALIGN_CENTER" />
+                <node
+                  class="wxFilePickerCtrl"
+                  style="wxFLP_FILE_MUST_EXIST|wxFLP_OPEN|wxFLP_USE_TEXTCTRL"
+                  var_name="m_PchHeaderPicker"
+                  wildcard="Header files|*.h;*.hh;*.hpp;*.hxx"
+                  wxEVT_FILEPICKER_CHANGED="OnPchHeaderChanged" />
               </node>
-              <node class="wxBoxSizer" var_name="box_sizer6" borders="wxLEFT|wxRIGHT|wxBOTTOM" flags="wxEXPAND">
-                <node class="wxStaticText" class_access="none" label="PCH &amp;Source:" var_name="staticText5" />
-                <node class="wxFilePickerCtrl" style="wxFLP_FILE_MUST_EXIST|wxFLP_OPEN|wxFLP_USE_TEXTCTRL" var_name="m_PchSrcPicker" wildcard="Source files|*.cpp;*.cc;*.cxx" wxEVT_FILEPICKER_CHANGED="OnPchSrcChanged" />
+              <node
+                class="wxBoxSizer"
+                var_name="box_sizer6"
+                borders="wxLEFT|wxRIGHT|wxBOTTOM"
+                flags="wxEXPAND">
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="PCH &amp;Source:"
+                  var_name="staticText5" />
+                <node
+                  class="wxFilePickerCtrl"
+                  style="wxFLP_FILE_MUST_EXIST|wxFLP_OPEN|wxFLP_USE_TEXTCTRL"
+                  var_name="m_PchSrcPicker"
+                  wildcard="Source files|*.cpp;*.cc;*.cxx"
+                  wxEVT_FILEPICKER_CHANGED="OnPchSrcChanged" />
               </node>
-              <node class="wxBoxSizer" var_name="box_sizer7" borders="wxLEFT|wxRIGHT|wxTOP" flags="wxEXPAND">
-                <node class="wxStaticText" class_access="none" label="&amp;Include Directories:" var_name="staticText6" alignment="wxALIGN_CENTER" proportion="1" />
-                <node class="wxButton" class_access="none" label="&amp;Add.." var_name="btnAddInclude" wxEVT_BUTTON="OnAddIncDir" />
+              <node
+                class="wxBoxSizer"
+                var_name="box_sizer7"
+                borders="wxLEFT|wxRIGHT|wxTOP"
+                flags="wxEXPAND">
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;Include Directories:"
+                  var_name="staticText6"
+                  alignment="wxALIGN_CENTER"
+                  proportion="1" />
+                <node
+                  class="wxButton"
+                  class_access="none"
+                  label="&amp;Add.."
+                  var_name="btnAddInclude"
+                  wxEVT_BUTTON="OnAddIncDir" />
               </node>
-              <node class="wxBoxSizer" var_name="box_sizer8" borders="wxLEFT|wxRIGHT|wxBOTTOM" flags="wxEXPAND">
-                <node class="wxTextCtrl" var_name="m_textIncludeDirs" validator_variable="m_IncludeDirs" borders="wxLEFT|wxRIGHT|wxBOTTOM" flags="wxEXPAND" proportion="1" />
+              <node
+                class="wxBoxSizer"
+                var_name="box_sizer8"
+                borders="wxLEFT|wxRIGHT|wxBOTTOM"
+                flags="wxEXPAND">
+                <node
+                  class="wxTextCtrl"
+                  var_name="m_textIncludeDirs"
+                  validator_variable="m_IncludeDirs"
+                  borders="wxLEFT|wxRIGHT|wxBOTTOM"
+                  flags="wxEXPAND"
+                  proportion="1" />
               </node>
-              <node class="wxStaticBoxSizer" class_access="none" label="Compiler Flags" var_name="static_box2" flags="wxEXPAND">
-                <node class="wxFlexGridSizer" flexible_direction="wxHORIZONTAL" growablecols="1" flags="wxEXPAND">
-                  <node class="wxStaticText" class_access="none" label="&amp;Common:" var_name="staticText7" tooltip="Compiler flags that will be used in all builds." alignment="wxALIGN_CENTER" />
-                  <node class="wxTextCtrl" class_access="none" var_name="commonFlags" validator_variable="m_CommonCppFlags" tooltip="Compiler flags that will be used in all builds." flags="wxEXPAND" />
-                  <node class="wxStaticText" class_access="none" label="&amp;Release:" var_name="staticText8" alignment="wxALIGN_CENTER" />
-                  <node class="wxTextCtrl" class_access="none" var_name="releaseFlags" validator_variable="m_ReleaseCppFlags" flags="wxEXPAND" />
-                  <node class="wxStaticText" class_access="none" label="&amp;Debug:" var_name="staticText9" tooltip="Compiler flags that will only be used in a Debug build." alignment="wxALIGN_CENTER" />
-                  <node class="wxTextCtrl" class_access="none" var_name="debugFlags" validator_variable="m_DebugCppFlags" tooltip="Compiler flags that will only be used in a Debug build." flags="wxEXPAND" />
+              <node
+                class="wxStaticBoxSizer"
+                label="Compiler Flags"
+                var_name="static_box2"
+                flags="wxEXPAND">
+                <node
+                  class="wxFlexGridSizer"
+                  flexible_direction="wxHORIZONTAL"
+                  growablecols="1"
+                  flags="wxEXPAND">
+                  <node
+                    class="wxStaticText"
+                    class_access="none"
+                    label="&amp;Common:"
+                    var_name="staticText7"
+                    tooltip="Compiler flags that will be used in all builds."
+                    alignment="wxALIGN_CENTER" />
+                  <node
+                    class="wxTextCtrl"
+                    class_access="none"
+                    var_name="commonFlags"
+                    validator_variable="m_CommonCppFlags"
+                    tooltip="Compiler flags that will be used in all builds."
+                    flags="wxEXPAND" />
+                  <node
+                    class="wxStaticText"
+                    class_access="none"
+                    label="&amp;Release:"
+                    var_name="staticText8"
+                    alignment="wxALIGN_CENTER" />
+                  <node
+                    class="wxTextCtrl"
+                    class_access="none"
+                    var_name="releaseFlags"
+                    validator_variable="m_ReleaseCppFlags"
+                    flags="wxEXPAND" />
+                  <node
+                    class="wxStaticText"
+                    class_access="none"
+                    label="&amp;Debug:"
+                    var_name="staticText9"
+                    tooltip="Compiler flags that will only be used in a Debug build."
+                    alignment="wxALIGN_CENTER" />
+                  <node
+                    class="wxTextCtrl"
+                    class_access="none"
+                    var_name="debugFlags"
+                    validator_variable="m_DebugCppFlags"
+                    tooltip="Compiler flags that will only be used in a Debug build."
+                    flags="wxEXPAND" />
                 </node>
               </node>
             </node>
           </node>
-          <node class="BookPage" label="Libs" var_name="panel2" background_colour="wxSYS_COLOUR_BTNFACE" window_style="wxTAB_TRAVERSAL">
-            <node class="wxBoxSizer" orientation="wxVERTICAL" var_name="parent_sizer4">
-              <node class="wxBoxSizer" var_name="box_sizer9" borders="wxLEFT|wxRIGHT|wxTOP" flags="wxEXPAND">
-                <node class="wxStaticText" class_access="none" label="&amp;Common Libraries:" var_name="staticText10" alignment="wxALIGN_BOTTOM" proportion="1" />
-                <node class="wxButton" class_access="none" label="&amp;Add.." var_name="btnAddCommonLibrary" wxEVT_BUTTON="OnAddCommonLibraries" />
+          <node
+            class="BookPage"
+            label="Libs"
+            var_name="panel2"
+            background_colour="wxSYS_COLOUR_BTNFACE"
+            window_style="wxTAB_TRAVERSAL">
+            <node
+              class="wxBoxSizer"
+              orientation="wxVERTICAL"
+              var_name="parent_sizer4">
+              <node
+                class="wxBoxSizer"
+                var_name="box_sizer9"
+                borders="wxLEFT|wxRIGHT|wxTOP"
+                flags="wxEXPAND">
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;Common Libraries:"
+                  var_name="staticText10"
+                  alignment="wxALIGN_BOTTOM"
+                  proportion="1" />
+                <node
+                  class="wxButton"
+                  class_access="none"
+                  label="&amp;Add.."
+                  var_name="btnAddCommonLibrary"
+                  wxEVT_BUTTON="OnAddCommonLibraries" />
               </node>
-              <node class="wxBoxSizer" var_name="box_sizer10" borders="wxLEFT|wxRIGHT|wxBOTTOM" flags="wxEXPAND">
-                <node class="wxTextCtrl" var_name="m_commonLibs" validator_variable="m_CommonLibs" borders="wxLEFT|wxRIGHT|wxBOTTOM" flags="wxEXPAND" proportion="1" />
+              <node
+                class="wxBoxSizer"
+                var_name="box_sizer10"
+                borders="wxLEFT|wxRIGHT|wxBOTTOM"
+                flags="wxEXPAND">
+                <node
+                  class="wxTextCtrl"
+                  var_name="m_commonLibs"
+                  validator_variable="m_CommonLibs"
+                  borders="wxLEFT|wxRIGHT|wxBOTTOM"
+                  flags="wxEXPAND"
+                  proportion="1" />
               </node>
-              <node class="wxBoxSizer" var_name="box_sizer11" borders="wxLEFT|wxRIGHT|wxTOP" flags="wxEXPAND">
-                <node class="wxStaticText" class_access="none" label="&amp;Release Libraries:" var_name="staticText11" alignment="wxALIGN_BOTTOM" proportion="1" />
-                <node class="wxButton" class_access="none" label="&amp;Add.." var_name="btnAddReleaseLibraries" wxEVT_BUTTON="OnAddReleaseLibraries" />
+              <node
+                class="wxBoxSizer"
+                var_name="box_sizer11"
+                borders="wxLEFT|wxRIGHT|wxTOP"
+                flags="wxEXPAND">
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;Release Libraries:"
+                  var_name="staticText11"
+                  alignment="wxALIGN_BOTTOM"
+                  proportion="1" />
+                <node
+                  class="wxButton"
+                  class_access="none"
+                  label="&amp;Add.."
+                  var_name="btnAddReleaseLibraries"
+                  wxEVT_BUTTON="OnAddReleaseLibraries" />
               </node>
-              <node class="wxBoxSizer" var_name="box_sizer14" borders="wxLEFT|wxRIGHT|wxBOTTOM" flags="wxEXPAND">
-                <node class="wxTextCtrl" var_name="m_releaseLibs" validator_variable="m_ReleaseLibs" borders="wxLEFT|wxRIGHT|wxBOTTOM" flags="wxEXPAND" proportion="1" />
+              <node
+                class="wxBoxSizer"
+                var_name="box_sizer14"
+                borders="wxLEFT|wxRIGHT|wxBOTTOM"
+                flags="wxEXPAND">
+                <node
+                  class="wxTextCtrl"
+                  var_name="m_releaseLibs"
+                  validator_variable="m_ReleaseLibs"
+                  borders="wxLEFT|wxRIGHT|wxBOTTOM"
+                  flags="wxEXPAND"
+                  proportion="1" />
               </node>
-              <node class="wxBoxSizer" var_name="box_sizer12" borders="wxLEFT|wxRIGHT|wxTOP" flags="wxEXPAND">
-                <node class="wxStaticText" class_access="none" label="&amp;Debug Libraries:" var_name="staticText12" alignment="wxALIGN_BOTTOM" proportion="1" />
-                <node class="wxButton" class_access="none" label="&amp;Add.." var_name="btnAddDebugLibraries" wxEVT_BUTTON="OnAddDebugLibraries" />
+              <node
+                class="wxBoxSizer"
+                var_name="box_sizer12"
+                borders="wxLEFT|wxRIGHT|wxTOP"
+                flags="wxEXPAND">
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;Debug Libraries:"
+                  var_name="staticText12"
+                  alignment="wxALIGN_BOTTOM"
+                  proportion="1" />
+                <node
+                  class="wxButton"
+                  class_access="none"
+                  label="&amp;Add.."
+                  var_name="btnAddDebugLibraries"
+                  wxEVT_BUTTON="OnAddDebugLibraries" />
               </node>
-              <node class="wxBoxSizer" var_name="box_sizer15" borders="wxLEFT|wxRIGHT|wxBOTTOM" flags="wxEXPAND">
-                <node class="wxTextCtrl" var_name="m_debugLibs" validator_variable="m_DebugLibs" borders="wxLEFT|wxRIGHT|wxBOTTOM" flags="wxEXPAND" proportion="1" />
+              <node
+                class="wxBoxSizer"
+                var_name="box_sizer15"
+                borders="wxLEFT|wxRIGHT|wxBOTTOM"
+                flags="wxEXPAND">
+                <node
+                  class="wxTextCtrl"
+                  var_name="m_debugLibs"
+                  validator_variable="m_DebugLibs"
+                  borders="wxLEFT|wxRIGHT|wxBOTTOM"
+                  flags="wxEXPAND"
+                  proportion="1" />
               </node>
-              <node class="wxBoxSizer" var_name="box_sizer13" borders="wxLEFT|wxRIGHT|wxTOP" flags="wxEXPAND">
-                <node class="wxStaticText" class_access="none" label="&amp;Build and link to these libraries:" var_name="staticText13" alignment="wxALIGN_BOTTOM" proportion="1" />
-                <node class="wxButton" class_access="none" label="&amp;Add.." var_name="btnAddBuildLibraries" wxEVT_BUTTON="OnAddBuildLibraries" />
+              <node
+                class="wxBoxSizer"
+                var_name="box_sizer13"
+                borders="wxLEFT|wxRIGHT|wxTOP"
+                flags="wxEXPAND">
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="&amp;Build and link to these libraries:"
+                  var_name="staticText13"
+                  alignment="wxALIGN_BOTTOM"
+                  proportion="1" />
+                <node
+                  class="wxButton"
+                  class_access="none"
+                  label="&amp;Add.."
+                  var_name="btnAddBuildLibraries"
+                  wxEVT_BUTTON="OnAddBuildLibraries" />
               </node>
-              <node class="wxBoxSizer" var_name="box_sizer16" borders="wxLEFT|wxRIGHT|wxBOTTOM" flags="wxEXPAND">
-                <node class="wxTextCtrl" var_name="m_buildLibs" validator_variable="m_BuildLibs" borders="wxLEFT|wxRIGHT|wxBOTTOM" flags="wxEXPAND" proportion="1" />
+              <node
+                class="wxBoxSizer"
+                var_name="box_sizer16"
+                borders="wxLEFT|wxRIGHT|wxBOTTOM"
+                flags="wxEXPAND">
+                <node
+                  class="wxTextCtrl"
+                  var_name="m_buildLibs"
+                  validator_variable="m_BuildLibs"
+                  borders="wxLEFT|wxRIGHT|wxBOTTOM"
+                  flags="wxEXPAND"
+                  proportion="1" />
               </node>
             </node>
           </node>
-          <node class="BookPage" label="Linker" var_name="panel6" background_colour="wxSYS_COLOUR_BTNFACE" window_style="wxTAB_TRAVERSAL">
-            <node class="wxBoxSizer" orientation="wxVERTICAL" var_name="parent_sizer8">
-              <node class="wxStaticBoxSizer" class_access="none" label="Linker Flags" var_name="static_box6" flags="wxEXPAND">
-                <node class="wxFlexGridSizer" var_name="flex_grid_sizer5" flexible_direction="wxHORIZONTAL" growablecols="1" flags="wxEXPAND">
-                  <node class="wxStaticText" class_access="none" label="&amp;Common:" var_name="staticText23" tooltip="Compiler flags that will be used in all builds." alignment="wxALIGN_CENTER" />
-                  <node class="wxTextCtrl" class_access="none" var_name="commonFlags4" validator_variable="m_CommonLinkFlags" tooltip="Compiler flags that will be used in all builds." flags="wxEXPAND" />
-                  <node class="wxStaticText" class_access="none" label="&amp;Release:" var_name="staticText24" alignment="wxALIGN_CENTER" />
-                  <node class="wxTextCtrl" class_access="none" var_name="releaseFlags4" validator_variable="m_ReleaseLinkFlags" flags="wxEXPAND" />
-                  <node class="wxStaticText" class_access="none" label="&amp;Debug:" var_name="staticText25" tooltip="Compiler flags that will only be used in a Debug build." alignment="wxALIGN_CENTER" />
-                  <node class="wxTextCtrl" class_access="none" var_name="debugFlags4" validator_variable="m_DebugLinkFlags" tooltip="Compiler flags that will only be used in a Debug build." flags="wxEXPAND" />
+          <node
+            class="BookPage"
+            label="Linker"
+            var_name="panel6"
+            background_colour="wxSYS_COLOUR_BTNFACE"
+            window_style="wxTAB_TRAVERSAL">
+            <node
+              class="wxBoxSizer"
+              orientation="wxVERTICAL"
+              var_name="parent_sizer8">
+              <node
+                class="wxStaticBoxSizer"
+                label="Linker Flags"
+                var_name="static_box6"
+                flags="wxEXPAND">
+                <node
+                  class="wxFlexGridSizer"
+                  var_name="flex_grid_sizer5"
+                  flexible_direction="wxHORIZONTAL"
+                  growablecols="1"
+                  flags="wxEXPAND">
+                  <node
+                    class="wxStaticText"
+                    class_access="none"
+                    label="&amp;Common:"
+                    var_name="staticText23"
+                    tooltip="Compiler flags that will be used in all builds."
+                    alignment="wxALIGN_CENTER" />
+                  <node
+                    class="wxTextCtrl"
+                    class_access="none"
+                    var_name="commonFlags4"
+                    validator_variable="m_CommonLinkFlags"
+                    tooltip="Compiler flags that will be used in all builds."
+                    flags="wxEXPAND" />
+                  <node
+                    class="wxStaticText"
+                    class_access="none"
+                    label="&amp;Release:"
+                    var_name="staticText24"
+                    alignment="wxALIGN_CENTER" />
+                  <node
+                    class="wxTextCtrl"
+                    class_access="none"
+                    var_name="releaseFlags4"
+                    validator_variable="m_ReleaseLinkFlags"
+                    flags="wxEXPAND" />
+                  <node
+                    class="wxStaticText"
+                    class_access="none"
+                    label="&amp;Debug:"
+                    var_name="staticText25"
+                    tooltip="Compiler flags that will only be used in a Debug build."
+                    alignment="wxALIGN_CENTER" />
+                  <node
+                    class="wxTextCtrl"
+                    class_access="none"
+                    var_name="debugFlags4"
+                    validator_variable="m_DebugLinkFlags"
+                    tooltip="Compiler flags that will only be used in a Debug build."
+                    flags="wxEXPAND" />
                 </node>
               </node>
-              <node class="wxBoxSizer" var_name="box_sizer18" flags="wxEXPAND">
-                <node class="wxStaticText" class_access="none" label="Dynamic CRT:" var_name="staticText26" alignment="wxALIGN_CENTER" />
-                <node class="wxCheckBox" checked="true" class_access="none" label="Release" var_name="checkBox2" validator_variable="m_isReleaseDllCRT" />
-                <node class="wxCheckBox" checked="true" class_access="none" label="Debug" var_name="checkBox3" validator_variable="m_isDebugDllCRT" />
+              <node
+                class="wxBoxSizer"
+                var_name="box_sizer18"
+                flags="wxEXPAND">
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="Dynamic CRT:"
+                  var_name="staticText26"
+                  alignment="wxALIGN_CENTER" />
+                <node
+                  class="wxCheckBox"
+                  checked="true"
+                  class_access="none"
+                  label="Release"
+                  var_name="checkBox2"
+                  validator_variable="m_isReleaseDllCRT" />
+                <node
+                  class="wxCheckBox"
+                  checked="true"
+                  class_access="none"
+                  label="Debug"
+                  var_name="checkBox3"
+                  validator_variable="m_isDebugDllCRT" />
               </node>
-              <node class="wxBoxSizer" var_name="box_sizer19" flags="wxEXPAND">
-                <node class="wxStaticText" class_access="none" label="NATVIS File:" var_name="staticText27" alignment="wxALIGN_CENTER" />
-                <node class="wxFilePickerCtrl" var_name="m_NatvisPicker" wildcard="Natvis Files|*.natvis" proportion="1" />
+              <node
+                class="wxBoxSizer"
+                var_name="box_sizer19"
+                flags="wxEXPAND">
+                <node
+                  class="wxStaticText"
+                  class_access="none"
+                  label="NATVIS File:"
+                  var_name="staticText27"
+                  alignment="wxALIGN_CENTER" />
+                <node
+                  class="wxFilePickerCtrl"
+                  var_name="m_NatvisPicker"
+                  wildcard="Natvis Files|*.natvis"
+                  proportion="1" />
               </node>
             </node>
           </node>
-          <node class="BookPage" label="RC" var_name="panel3" background_colour="wxSYS_COLOUR_BTNFACE" window_style="wxTAB_TRAVERSAL">
-            <node class="wxBoxSizer" orientation="wxVERTICAL" var_name="parent_sizer5">
-              <node class="wxStaticBoxSizer" class_access="none" label="Resource compiler flags" var_name="static_box3" flags="wxEXPAND">
-                <node class="wxFlexGridSizer" var_name="flex_grid_sizer2" growablecols="1" flags="wxEXPAND">
-                  <node class="wxStaticText" class_access="none" label="Common:" var_name="staticText14" alignment="wxALIGN_CENTER" />
-                  <node class="wxTextCtrl" class_access="none" var_name="commonRCFlags" validator_variable="m_commonRcFlags" flags="wxEXPAND" />
-                  <node class="wxStaticText" class_access="none" label="Release:" var_name="staticText15" alignment="wxALIGN_CENTER" />
-                  <node class="wxTextCtrl" class_access="none" var_name="releaseRCFlags" validator_variable="m_releaseRcFlags" flags="wxEXPAND" />
-                  <node class="wxStaticText" class_access="none" label="Debug:" var_name="staticText16" alignment="wxALIGN_CENTER" />
-                  <node class="wxTextCtrl" class_access="none" var_name="debugRCFlags" validator_variable="m_debugRcFlags" flags="wxEXPAND" />
+          <node
+            class="BookPage"
+            label="RC"
+            var_name="panel3"
+            background_colour="wxSYS_COLOUR_BTNFACE"
+            window_style="wxTAB_TRAVERSAL">
+            <node
+              class="wxBoxSizer"
+              orientation="wxVERTICAL"
+              var_name="parent_sizer5">
+              <node
+                class="wxStaticBoxSizer"
+                label="Resource compiler flags"
+                var_name="static_box3"
+                flags="wxEXPAND">
+                <node
+                  class="wxFlexGridSizer"
+                  var_name="flex_grid_sizer2"
+                  growablecols="1"
+                  flags="wxEXPAND">
+                  <node
+                    class="wxStaticText"
+                    class_access="none"
+                    label="Common:"
+                    var_name="staticText14"
+                    alignment="wxALIGN_CENTER" />
+                  <node
+                    class="wxTextCtrl"
+                    class_access="none"
+                    var_name="commonRCFlags"
+                    validator_variable="m_commonRcFlags"
+                    flags="wxEXPAND" />
+                  <node
+                    class="wxStaticText"
+                    class_access="none"
+                    label="Release:"
+                    var_name="staticText15"
+                    alignment="wxALIGN_CENTER" />
+                  <node
+                    class="wxTextCtrl"
+                    class_access="none"
+                    var_name="releaseRCFlags"
+                    validator_variable="m_releaseRcFlags"
+                    flags="wxEXPAND" />
+                  <node
+                    class="wxStaticText"
+                    class_access="none"
+                    label="Debug:"
+                    var_name="staticText16"
+                    alignment="wxALIGN_CENTER" />
+                  <node
+                    class="wxTextCtrl"
+                    class_access="none"
+                    var_name="debugRCFlags"
+                    validator_variable="m_debugRcFlags"
+                    flags="wxEXPAND" />
                 </node>
               </node>
             </node>
           </node>
-          <node class="BookPage" label="CLang" var_name="panel5" background_colour="wxSYS_COLOUR_BTNFACE" window_style="wxTAB_TRAVERSAL">
-            <node class="wxBoxSizer" orientation="wxVERTICAL" var_name="parent_sizer7">
-              <node class="wxStaticBoxSizer" class_access="none" label="Additional flags for clang-cl (Windows)" var_name="static_box5" flags="wxEXPAND">
-                <node class="wxFlexGridSizer" var_name="flex_grid_sizer4" growablecols="1" flags="wxEXPAND">
-                  <node class="wxStaticText" class_access="none" label="Common:" var_name="staticText20" alignment="wxALIGN_CENTER" />
-                  <node class="wxTextCtrl" class_access="none" var_name="commonFlags3" validator_variable="m_commonClangFlags" flags="wxEXPAND" />
-                  <node class="wxStaticText" class_access="none" label="Release:" var_name="staticText21" alignment="wxALIGN_CENTER" />
-                  <node class="wxTextCtrl" class_access="none" var_name="releaseFlags3" validator_variable="m_releaseClangFlags" flags="wxEXPAND" />
-                  <node class="wxStaticText" class_access="none" label="Debug:" var_name="staticText22" alignment="wxALIGN_CENTER" />
-                  <node class="wxTextCtrl" class_access="none" var_name="debugFlags3" validator_variable="m_debugClangFlags" flags="wxEXPAND" />
+          <node
+            class="BookPage"
+            label="CLang"
+            var_name="panel5"
+            background_colour="wxSYS_COLOUR_BTNFACE"
+            window_style="wxTAB_TRAVERSAL">
+            <node
+              class="wxBoxSizer"
+              orientation="wxVERTICAL"
+              var_name="parent_sizer7">
+              <node
+                class="wxStaticBoxSizer"
+                label="Additional flags for clang-cl (Windows)"
+                var_name="static_box5"
+                flags="wxEXPAND">
+                <node
+                  class="wxFlexGridSizer"
+                  var_name="flex_grid_sizer4"
+                  growablecols="1"
+                  flags="wxEXPAND">
+                  <node
+                    class="wxStaticText"
+                    class_access="none"
+                    label="Common:"
+                    var_name="staticText20"
+                    alignment="wxALIGN_CENTER" />
+                  <node
+                    class="wxTextCtrl"
+                    class_access="none"
+                    var_name="commonFlags3"
+                    validator_variable="m_commonClangFlags"
+                    flags="wxEXPAND" />
+                  <node
+                    class="wxStaticText"
+                    class_access="none"
+                    label="Release:"
+                    var_name="staticText21"
+                    alignment="wxALIGN_CENTER" />
+                  <node
+                    class="wxTextCtrl"
+                    class_access="none"
+                    var_name="releaseFlags3"
+                    validator_variable="m_releaseClangFlags"
+                    flags="wxEXPAND" />
+                  <node
+                    class="wxStaticText"
+                    class_access="none"
+                    label="Debug:"
+                    var_name="staticText22"
+                    alignment="wxALIGN_CENTER" />
+                  <node
+                    class="wxTextCtrl"
+                    class_access="none"
+                    var_name="debugFlags3"
+                    validator_variable="m_debugClangFlags"
+                    flags="wxEXPAND" />
                 </node>
-                <node class="wxBoxSizer" var_name="box_sizer17" flags="wxEXPAND">
-                  <node class="wxCheckBox" class_access="none" label="Always use &amp;MS Linker (link.exe)" var_name="checkBox" validator_variable="m_useMSLinker" />
+                <node
+                  class="wxBoxSizer"
+                  var_name="box_sizer17"
+                  flags="wxEXPAND">
+                  <node
+                    class="wxCheckBox"
+                    class_access="none"
+                    label="Always use &amp;MS Linker (link.exe)"
+                    var_name="checkBox"
+                    validator_variable="m_useMSLinker" />
                 </node>
               </node>
             </node>
           </node>
-          <node class="BookPage" label="MIDL" var_name="panel4" background_colour="wxSYS_COLOUR_BTNFACE" window_style="wxTAB_TRAVERSAL">
-            <node class="wxBoxSizer" orientation="wxVERTICAL" var_name="parent_sizer6">
-              <node class="wxStaticBoxSizer" class_access="none" label="MIDL compiler flags" var_name="static_box4" flags="wxEXPAND">
-                <node class="wxFlexGridSizer" var_name="flex_grid_sizer3" growablecols="1" flags="wxEXPAND">
-                  <node class="wxStaticText" class_access="none" label="Common:" var_name="staticText17" alignment="wxALIGN_CENTER" />
-                  <node class="wxTextCtrl" class_access="none" var_name="commonFlags2" validator_variable="m_commonMidlFlags" flags="wxEXPAND" />
-                  <node class="wxStaticText" class_access="none" label="Release:" var_name="staticText18" alignment="wxALIGN_CENTER" />
-                  <node class="wxTextCtrl" class_access="none" var_name="releaseFlags2" validator_variable="m_releaseMidlFlags" flags="wxEXPAND" />
-                  <node class="wxStaticText" class_access="none" label="Debug:" var_name="staticText19" alignment="wxALIGN_CENTER" />
-                  <node class="wxTextCtrl" class_access="none" var_name="debugFlags2" validator_variable="m_debugMidlFlags" flags="wxEXPAND" />
+          <node
+            class="BookPage"
+            label="MIDL"
+            var_name="panel4"
+            background_colour="wxSYS_COLOUR_BTNFACE"
+            window_style="wxTAB_TRAVERSAL">
+            <node
+              class="wxBoxSizer"
+              orientation="wxVERTICAL"
+              var_name="parent_sizer6">
+              <node
+                class="wxStaticBoxSizer"
+                label="MIDL compiler flags"
+                var_name="static_box4"
+                flags="wxEXPAND">
+                <node
+                  class="wxFlexGridSizer"
+                  var_name="flex_grid_sizer3"
+                  growablecols="1"
+                  flags="wxEXPAND">
+                  <node
+                    class="wxStaticText"
+                    class_access="none"
+                    label="Common:"
+                    var_name="staticText17"
+                    alignment="wxALIGN_CENTER" />
+                  <node
+                    class="wxTextCtrl"
+                    class_access="none"
+                    var_name="commonFlags2"
+                    validator_variable="m_commonMidlFlags"
+                    flags="wxEXPAND" />
+                  <node
+                    class="wxStaticText"
+                    class_access="none"
+                    label="Release:"
+                    var_name="staticText18"
+                    alignment="wxALIGN_CENTER" />
+                  <node
+                    class="wxTextCtrl"
+                    class_access="none"
+                    var_name="releaseFlags2"
+                    validator_variable="m_releaseMidlFlags"
+                    flags="wxEXPAND" />
+                  <node
+                    class="wxStaticText"
+                    class_access="none"
+                    label="Debug:"
+                    var_name="staticText19"
+                    alignment="wxALIGN_CENTER" />
+                  <node
+                    class="wxTextCtrl"
+                    class_access="none"
+                    var_name="debugFlags2"
+                    validator_variable="m_debugMidlFlags"
+                    flags="wxEXPAND" />
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node class="wxStdDialogButtonSizer" flags="wxEXPAND" />
+        <node
+          class="wxStdDialogButtonSizer"
+          flags="wxEXPAND" />
       </node>
     </node>
   </node>

--- a/src/ui/vscodedlgBase.cpp
+++ b/src/ui/vscodedlgBase.cpp
@@ -13,9 +13,11 @@
 
 #include "vscodedlgBase.h"
 
-VsCodeDlgBase::VsCodeDlgBase(wxWindow* parent) : wxDialog()
+bool VsCodeDlgBase::Create(wxWindow *parent, wxWindowID id, const wxString &title,
+        const wxPoint&pos, const wxSize& size, long style, const wxString &name)
 {
-    Create(parent, wxID_ANY, wxString::FromUTF8("Create .vscode files"));
+    if (!wxDialog::Create(parent, id, title, pos, size, style, name))
+        return false;
 
     auto parent_sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -85,4 +87,6 @@ VsCodeDlgBase::VsCodeDlgBase(wxWindow* parent) : wxDialog()
 
     // Event handlers
     Bind(wxEVT_INIT_DIALOG, &VsCodeDlgBase::OnInit, this);
+
+    return true;
 }

--- a/src/ui/vscodedlgBase.h
+++ b/src/ui/vscodedlgBase.h
@@ -15,7 +15,17 @@
 class VsCodeDlgBase : public wxDialog
 {
 public:
-    VsCodeDlgBase(wxWindow* parent);
+    VsCodeDlgBase() {}
+    VsCodeDlgBase(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Create .vscode files"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr)
+    {
+        Create(parent, id, title, pos, size, style, name);
+    }
+
+    bool Create(wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = wxString::FromUTF8("Create .vscode files"),
+        const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize,
+        long style = wxDEFAULT_DIALOG_STYLE, const wxString &name = wxDialogNameStr);
 
 protected:
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a -cmake option to ttBld which creates a `CMakeLists.txt` and `CMakePresets.json` file based on `.srcfiles.yaml`. If `CMakeLists.txt` already exists, then a `CMakeLists.ttbld` file is created that can be used to compare and potentially merge changes. This should make it relatively easy to make changes to `.srcfiles.yaml` and then merge those changes into `CMakeLists.txt`.

Note that it's fine to leave .srcfiles.yaml in a src/ directory and for ttBld to be run in the root of the repository. The `CMakeLists.txt` will be created in the root, and the filename paths fixed up to reflect that they are in a subdirectory.

Closes #230