### PR TITLE
Support wxui_code.cmake in Files or DebugFiles sections

### DIFF
--- a/src/csrcfiles.cpp
+++ b/src/csrcfiles.cpp
@@ -296,6 +296,26 @@ void CSrcFiles::ProcessFile(std::string_view line)
             ProcessIncludeDirective(filename);
         return;
     }
+    else if (ttlib::contains(line, "wxui_code.cmake", tt::CASE::either))
+    {
+        ttlib::cstr root(line);
+        root.remove_filename();
+
+        ttlib::viewfile cmake_files;
+        if (cmake_files.ReadFile(line))
+        {
+            for (ttlib::sview iter: cmake_files)
+            {
+                if (iter.contains("${CMAKE_CURRENT_LIST_DIR}"))
+                {
+                    ttlib::cstr filename(root);
+                    filename.append_filename(iter.filename());
+                    ttlib::add_if(m_lstSrcFiles, filename);
+                }
+            }
+        }
+        return;
+    }
 
     ttlib::cstr filename = line;
     filename.erase_from('#');
@@ -338,6 +358,26 @@ void CSrcFiles::ProcessDebugFile(std::string_view line)
     if (filename.find('*') != tt::npos || filename.find('?') != tt::npos)
     {
         AddSourcePattern(filename);
+        return;
+    }
+    else if (ttlib::contains(line, "wxui_code.cmake", tt::CASE::either))
+    {
+        ttlib::cstr root(line);
+        root.remove_filename();
+
+        ttlib::viewfile cmake_files;
+        if (cmake_files.ReadFile(line))
+        {
+            for (ttlib::sview iter: cmake_files)
+            {
+                if (iter.contains("${CMAKE_CURRENT_LIST_DIR}"))
+                {
+                    ttlib::cstr filename(root);
+                    filename.append_filename(iter.filename());
+                    ttlib::add_if(m_lstDebugFiles, filename);
+                }
+            }
+        }
         return;
     }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -17,7 +17,7 @@
 
 // Any time you add an option below, you need to increment this version number and then add it to the aoptVersions
 // list
-const char* txtOptVersion { "1.8.0" };
+const char* txtOptVersion { "1.8.1" };
 
 // clang-format off
 static OPT::VERSION aoptVersions[]

--- a/src/precompile/pch.h
+++ b/src/precompile/pch.h
@@ -73,7 +73,7 @@
 
 // Version is also set in writesrc.h and ttBld.rc -- if changed, change in all three locations
 
-inline constexpr const auto txtVersion = "ttBld 1.8.0";
+inline constexpr const auto txtVersion = "ttBld 1.8.1";
 inline constexpr const auto txtCopyRight = "Copyright (c) 2002-2021 KeyWorks Software";
 inline constexpr const auto txtAppname = "ttBld";
 

--- a/src/ttBld.manifest
+++ b/src/ttBld.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity
-    version="1.8.0.0"
+    version="1.8.1.0"
     processorArchitecture="*"
     name="KeyWorks.Software.ttBld"
     type="win32"

--- a/src/ttBld.rc
+++ b/src/ttBld.rc
@@ -20,14 +20,14 @@ BEGIN
             VALUE "Comments", "Released under Apache License\0"
             VALUE "CompanyName", "KeyWorks Software\0"
             VALUE "FileDescription", "Ninja Build Script generator\0"
-            VALUE "FileVersion", "1.8.0.0\0"
+            VALUE "FileVersion", "1.8.1.0\0"
             VALUE "InternalName", "ttBld\0"
             VALUE "LegalCopyright", "Copyright (c) 2002-2021 KeyWorks Software\0"
             VALUE "LegalTrademarks", "\0"
             VALUE "OriginalFilename", "ttBld.exe\0"
             VALUE "PrivateBuild", "\0"
             VALUE "ProductName", "ttBld\0"
-            VALUE "ProductVersion", "1.8.0\0"
+            VALUE "ProductVersion", "1.8.1\0"
             VALUE "SpecialBuild", "\0"
         END
     END

--- a/src/writesrc.h
+++ b/src/writesrc.h
@@ -10,7 +10,7 @@
 #include "csrcfiles.h"
 
 inline constexpr const char* txtNinjaVerFormat =
-    "# Updated by ttBld.exe version 1.8.0 -- see https://github.com/KeyWorksRW/ttBld";
+    "# Updated by ttBld.exe version 1.8.1 -- see https://github.com/KeyWorksRW/ttBld";
 
 // This class inherits from CSrcFiles and can be used anywhere CSrcFiles is used.
 class CWriteSrcFiles : public CSrcFiles


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds support for using a wxui_code.cmake file within a Files: or DebugFiles: section. If encountered, it will add all the source files specified by the CMake file.