### PR TITLE
Fixes for CodeQL and clang-format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,18 +8,18 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 if (MSVC)
     # /O1 often results in faster code than /O2 due to CPU caching
-    string(REPLACE "/O2" "/O1" cl_optimize ${CMAKE_CXX_FLAGS_RELEASE})
+    string(REPLACE "/O2" "/O1" cl_optimize "${CMAKE_CXX_FLAGS_RELEASE}")
     set(CMAKE_CXX_FLAGS_RELEASE ${cl_optimize} CACHE STRING "C++ Release flags" FORCE)
 
-    string(REPLACE "/O2" "/O1" cl_optimize ${CMAKE_C_FLAGS_RELEASE})
+    string(REPLACE "/O2" "/O1" cl_optimize "${CMAKE_C_FLAGS_RELEASE}")
     set(CMAKE_C_FLAGS_RELEASE ${cl_optimize} CACHE STRING "C Release flags" FORCE)
 
     # Using /Z7 instead of /Zi to avoid blocking while parallel compilers write to the pdb file.
     # This can considerably speed up build times at the cost of larger object files.
-    string(REPLACE "/Zi" "/Z7" z_seven ${CMAKE_CXX_FLAGS_DEBUG})
+    string(REPLACE "/Zi" "/Z7" z_seven "${CMAKE_CXX_FLAGS_DEBUG}")
     set(CMAKE_CXX_FLAGS_DEBUG ${z_seven} CACHE STRING "C++ Debug flags" FORCE)
 
-    string(REPLACE "/Zi" "/Z7" z_seven ${CMAKE_C_FLAGS_DEBUG})
+    string(REPLACE "/Zi" "/Z7" z_seven "${CMAKE_C_FLAGS_DEBUG}")
     set(CMAKE_C_FLAGS_DEBUG ${z_seven} CACHE STRING "C Debug flags" FORCE)
 
     # Use static runtime for Release builds to run with Wine without needing to install the dlls
@@ -27,9 +27,9 @@ if (MSVC)
 else()
     # This should work for gcc and clang (including xcode which is based on clang)
     # -O2 can result in faster code than -O3 due to CPU caching.
-    string(REPLACE "-O3" "-O2" cl_optimize ${CMAKE_CXX_FLAGS_RELEASE})
+    string(REPLACE "-O3" "-O2" cl_optimize "${CMAKE_CXX_FLAGS_RELEASE}")
     set(CMAKE_CXX_FLAGS_RELEASE ${cl_optimize} CACHE STRING "C++ Release flags" FORCE)
-    string(REPLACE "-O3" "-O2" cl_optimize ${CMAKE_C_FLAGS_RELEASE})
+    string(REPLACE "-O3" "-O2" cl_optimize "${CMAKE_C_FLAGS_RELEASE}")
     set(CMAKE_C_FLAGS_RELEASE ${cl_optimize} CACHE STRING "C Release flags" FORCE)
 endif()
 
@@ -60,11 +60,6 @@ include(src/file_list.cmake)     # This will set ${file_list} with a list of sou
 
 if (WIN32)
     set(setup_dir ${widget_cmake_dir}/win)
-    set(win_ttlib_sources
-        ttlib/src/winsrc/ttregistry.cpp  # Class for working with the Windows registry
-
-        $<$<CONFIG:Debug>:ttlib/src/winsrc/ttdebug_min.cpp>
-    )
 
     set(win_resource "src/ttBld.rc")
 else()

--- a/src/.srcfiles.yaml
+++ b/src/.srcfiles.yaml
@@ -69,8 +69,5 @@ Files:
     ui/optionsdlgBase.cpp        # wxUiEditor generated file
     ui/vscodedlgBase.cpp         # wxUiEditor generated file
 
-    # ttLib files
-
-
 DebugFiles:
-    ../ttlib/src/winsrc/ttdebug_min.cpp  # we use our own version of this to minimize Windows code requirements
+    ../ttLib_wx/src/assertion_dlg.cpp  # Assertion Dialog

--- a/src/.srcfiles.yaml
+++ b/src/.srcfiles.yaml
@@ -44,6 +44,7 @@ Files:
     vscode.cpp          # Creates/updates .vscode files
     writesrc.cpp        # Writes a new or update srcfiles.yaml file
     yamalize.cpp        # Used to convert .srcfiles to .vscode/srcfiles.yaml
+    ttconsole.cpp       # Sets/restores console foreground color
 
     convert/convert.cpp          # Various conversion methods
     convert/readcodelite.cpp     # Class for converting a CodeLite .project file to .srcfiles.yaml
@@ -70,17 +71,6 @@ Files:
 
     # ttLib files
 
-    ../ttlib/src/ttconsole.cpp   # Sets/restores console foreground color
-    ../ttlib/src/ttcstr.cpp      # Class for handling zero-terminated char strings.
-    ../ttlib/src/ttcview.cpp     # string_view functionality on a zero-terminated char string.
-    ../ttlib/src/ttlibspace.cpp  # ttlib namespace functions
-    ../ttlib/src/ttmultistr.cpp  # Breaks a single string into multiple strings
-    ../ttlib/src/ttparser.cpp    # Command line parser
-    ../ttlib/src/ttstr.cpp       # ttString -- enhanced version of wxString
-    ../ttlib/src/ttsview.cpp     # std::string_view with additional methods
-    ../ttlib/src/tttextfile.cpp  # Classes for reading and writing text files.
-
-    ../ttlib/src/winsrc/ttregistry.cpp  # Class for working with the Windows registry
 
 DebugFiles:
     ../ttlib/src/winsrc/ttdebug_min.cpp  # we use our own version of this to minimize Windows code requirements

--- a/src/convert/readcodelite.cpp
+++ b/src/convert/readcodelite.cpp
@@ -5,7 +5,7 @@
 // License:   Apache License see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include "ttcwd.h"       // cwd -- Class for storing and optionally restoring the current directory
+#include "ttcwd.h"          // cwd -- Class for storing and optionally restoring the current directory
 #include <ttmultistr_wx.h>  // multistr -- Breaks a single string into multiple strings
 
 #include "convert.h"  // CConvert, CVcxWrite

--- a/src/convert/readdsp.cpp
+++ b/src/convert/readdsp.cpp
@@ -5,7 +5,7 @@
 // License:   Apache License see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include "ttcwd.h"       // cwd -- Class for storing and optionally restoring the current directory
+#include "ttcwd.h"          // cwd -- Class for storing and optionally restoring the current directory
 #include <ttmultistr_wx.h>  // multistr -- Breaks a single string into multiple strings
 #include <tttextfile_wx.h>  // textfile -- Classes for reading and writing line-oriented files
 

--- a/src/convert/readvc.cpp
+++ b/src/convert/readvc.cpp
@@ -5,7 +5,7 @@
 // License:   Apache License see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include "ttcwd.h"       // cwd -- Class for storing and optionally restoring the current directory
+#include "ttcwd.h"          // cwd -- Class for storing and optionally restoring the current directory
 #include <ttmultistr_wx.h>  // multistr -- Breaks a single string into multiple strings
 
 #include "convert.h"  // CConvert, CVcxWrite

--- a/src/convert/write_cmake.cpp
+++ b/src/convert/write_cmake.cpp
@@ -5,7 +5,7 @@
 // License:   Apache License -- see ../../LICENSE
 /////////////////////////////////////////////////////////////////////////////
 
-#include "ttcwd.h"       // cwd -- Class for storing and optionally restoring the current directory
+#include "ttcwd.h"          // cwd -- Class for storing and optionally restoring the current directory
 #include <ttmultistr_wx.h>  // multistr -- Breaks a single string into multiple strings
 #include <ttsview_wx.h>     // sview -- std::string_view with additional methods
 #include <tttextfile_wx.h>  // textfile -- Classes for reading and writing line-oriented files

--- a/src/convert/wxWidgets_file.cpp
+++ b/src/convert/wxWidgets_file.cpp
@@ -153,7 +153,6 @@ inline constexpr const auto txt_wxCLib_sources = {
     "common/extended.c"
 };
 
-
 // build/files doesn't include the scintilla *.cxx files, so we hard-code them here
 
 inline constexpr const auto txt_scintilla_files = {

--- a/src/csrcfiles.cpp
+++ b/src/csrcfiles.cpp
@@ -9,9 +9,9 @@
 
 #include <wx/filefn.h>  // File- and directory-related functions
 
-#include "ttcwd.h"                     // Class for storing and optionally restoring the current directory
-#include <ttmultistr_wx.h>             // multistr -- Breaks a single string into multiple strings
-#include <tttextfile_wx.h>             // Classes for reading and writing line-oriented files
+#include "ttcwd.h"          // Class for storing and optionally restoring the current directory
+#include <ttmultistr_wx.h>  // multistr -- Breaks a single string into multiple strings
+#include <tttextfile_wx.h>  // Classes for reading and writing line-oriented files
 
 #include "csrcfiles.h"  // CSrcFiles
 

--- a/src/file_list.cmake
+++ b/src/file_list.cmake
@@ -31,7 +31,7 @@ set (file_list
     ${CMAKE_CURRENT_LIST_DIR}/convert/wxWidgets_file.cpp   # Convert wxWidgets build/file to CMake file list
 
     ${CMAKE_CURRENT_LIST_DIR}/../ttLib_wx/src/assertion_dlg.cpp  # Assertion Dialog
-    ${CMAKE_CURRENT_LIST_DIR}/../ttLib/src/ttconsole.cpp         # Sets/restores console foreground color
+    ${CMAKE_CURRENT_LIST_DIR}/ttconsole.cpp                      # Sets/restores console foreground color
 
     # DO NOT RUN clang-format on the following file! We need to be able to sync changes from the original repository
     ${CMAKE_CURRENT_LIST_DIR}/pugixml/pugixml.cpp          # Built directly rather than building a library

--- a/src/image_hdr.cpp
+++ b/src/image_hdr.cpp
@@ -11,7 +11,7 @@
 #include <wx/mstream.h>   // Memory stream classes
 #include <wx/wfstream.h>  // File stream classes
 
-#include <ttstring_wx.h>       // ttString -- wxString with additional methods similar to ttlib::cstr
+#include <ttstring_wx.h>    // ttString -- wxString with additional methods similar to ttlib::cstr
 #include <tttextfile_wx.h>  // textfile -- Classes for reading and writing line-oriented files
 
 // clang-format off

--- a/src/mainapp.cpp
+++ b/src/mainapp.cpp
@@ -38,8 +38,8 @@
 
 #include "../../ttLib/include/ttconsole.h"  // ttConsoleColor
 
-#include "ttcwd_wx.h"      // cwd -- Class for storing and optionally restoring the current directory
-#include "ttparser_wx.h"   // cmd -- Command line parser
+#include "ttcwd_wx.h"     // cwd -- Class for storing and optionally restoring the current directory
+#include "ttparser_wx.h"  // cmd -- Command line parser
 
 #include "convert.h"         // CConvert
 #include "funcs.h"           // List of function declarations

--- a/src/ninja.cpp
+++ b/src/ninja.cpp
@@ -11,7 +11,7 @@
 #include <wx/arrstr.h>  // wxArrayString class
 #include <wx/dir.h>     // wxDir is a class for enumerating the files in a directory
 
-#include "ttcwd.h"       // Class for storing and optionally restoring the current directory
+#include "ttcwd.h"          // Class for storing and optionally restoring the current directory
 #include <ttmultistr_wx.h>  // multistr -- Breaks a single string into multiple strings
 
 #include "ninja.h"     // CNinja

--- a/src/precompile/pch.h
+++ b/src/precompile/pch.h
@@ -73,7 +73,7 @@
 #include "ttcview.h"  // ttlib::cview -- std::string_view functionality on a zero-terminated char string.
 #include "ttsview.h"  // ttlib::sview -- std::string_view with additional methods
 
-#include "ttcstr.h"      // ttlib::cstr -- std::string with additional functions
+#include "ttcstr.h"  // ttlib::cstr -- std::string with additional functions
 
 // Version is also set in writesrc.h and ttBld.rc -- if changed, change in all three locations
 

--- a/src/rcdep.cpp
+++ b/src/rcdep.cpp
@@ -7,7 +7,7 @@
 
 #include <exception>
 
-#include "ttcwd.h"       // cwd -- Class for storing and optionally restoring the current directory
+#include "ttcwd.h"          // cwd -- Class for storing and optionally restoring the current directory
 #include <tttextfile_wx.h>  // Classes for reading and writing line-oriented files
 
 #include "ninja.h"  // CNinja

--- a/src/readcodelite.cpp
+++ b/src/readcodelite.cpp
@@ -8,7 +8,7 @@
 
 #include <string>
 
-#include "ttcwd.h"       // cwd -- Class for storing and optionally restoring the current directory
+#include "ttcwd.h"          // cwd -- Class for storing and optionally restoring the current directory
 #include <ttmultistr_wx.h>  // multistr -- Breaks a single string into multiple strings
 
 #include "convert.h"  // CConvert, CVcxWrite

--- a/src/ttconsole.cpp
+++ b/src/ttconsole.cpp
@@ -1,0 +1,115 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:      ttconsole.cpp
+// Purpose:   Sets/restores console foreground color
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2019-2020 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#if !defined(_WIN32)
+    #include <cstdlib>
+#endif
+
+#include "ttconsole.h"  // concolor
+
+using namespace ttlib;
+
+concolor::concolor(int clr)
+{
+#if defined(_WIN32)
+    // save the current color on Windows. Not needed for ansi-enabled consoles which use reset
+    CONSOLE_SCREEN_BUFFER_INFO csbi;
+    GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
+    m_defAttributes = (uint16_t) csbi.wAttributes;
+#endif
+
+    SetColor(clr);
+}
+
+concolor::~concolor()
+{
+    ResetColor();
+};
+
+void concolor::SetColor(int clr)
+{
+#if defined(_WIN32)
+    auto hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
+
+    CONSOLE_SCREEN_BUFFER_INFO csbi;
+
+    GetConsoleScreenBufferInfo(hConsole, &csbi);
+
+    // Foreground colors take up the least significant byte
+    SetConsoleTextAttribute(hConsole, (csbi.wAttributes & 0xFFF0) | (WORD) clr);
+
+#else   // following section uses ANSI escape codes
+    const char* color;
+
+    switch (clr)
+    {
+        case BLACK:
+            color = "\033[22;30m";
+            break;
+        case BLUE:
+            color = "\033[22;34m";
+            break;
+        case GREEN:
+            color = "\033[22;32m";
+            break;
+        case CYAN:
+            color = "\033[22;36m";
+            break;
+        case RED:
+            color = "\033[22;31m";
+            break;
+        case MAGENTA:
+            color = "\033[22;35m";
+            break;
+        case BROWN:
+            color = "\033[22;33m";
+            break;
+        case GREY:
+            color = "\033[22;37m";
+            break;
+        case DARKGREY:
+            color = "\033[01;30m";
+            break;
+        case LIGHTBLUE:
+            color = "\033[01;34m";
+            break;
+        case LIGHTGREEN:
+            color = "\033[01;32m";
+            break;
+        case LIGHTCYAN:
+            color = "\033[01;36m";
+            break;
+        case LIGHTRED:
+            color = "\033[01;31m";
+            break;
+        case LIGHTMAGENTA:
+            color = "\033[01;35m";
+            break;
+        case YELLOW:
+            color = "\033[01;33m";
+            break;
+        case WHITE:
+            color = "\033[01;37m";
+            break;
+        default:
+            color = "";
+            break;
+    }
+
+    std::cout << color;
+#endif  // !defined(_WIN32)
+}
+
+void concolor::ResetColor()
+{
+#if defined(_WIN32)
+    SetConsoleTextAttribute(GetStdHandle(STD_OUTPUT_HANDLE), (WORD) m_defAttributes);
+#else
+    std::cout << "\033[0m";
+#endif
+}

--- a/src/ttconsole.h
+++ b/src/ttconsole.h
@@ -1,0 +1,50 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:      ttconsole.h
+// Purpose:   Sets/restores console foreground color
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2019-2020 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <stdint.h>
+
+namespace ttlib
+{
+    class concolor
+    {
+    public:
+        enum
+        {
+            BLACK,
+            BLUE,
+            GREEN,
+            CYAN,
+            RED,
+            MAGENTA,
+            BROWN,
+            GREY,
+            DARKGREY,
+            LIGHTBLUE,
+            LIGHTGREEN,
+            LIGHTCYAN,
+            LIGHTRED,
+            LIGHTMAGENTA,
+            YELLOW,
+            WHITE
+        };
+
+        concolor(int clr);
+        ~concolor();
+
+        void SetColor(int clr);
+        void ResetColor();
+
+    private:
+#if defined(_WIN32)
+        uint16_t m_defAttributes;
+#endif
+    };
+
+}  // namespace ttlib

--- a/src/ttcwd.h
+++ b/src/ttcwd.h
@@ -14,7 +14,7 @@
     #error "You must include wx/defs.h before including this file."
 #endif
 
-#include "ttcstr_wx.h"  // ttString -- wxString with additional methods similar to ttlib::cstr
+#include "ttcstr_wx.h"    // ttString -- wxString with additional methods similar to ttlib::cstr
 #include "ttstring_wx.h"  // ttString -- wxString with additional methods similar to ttlib::cstr
 
 namespace ttlib
@@ -50,7 +50,6 @@ namespace ttlib
     private:
         ttlib::cstr m_restore;
     };
-
 
     /// Retrieves the current working directory. Construct with (true) to restore the
     /// directory in the dtor.

--- a/src/ui/optionsdlg.h
+++ b/src/ui/optionsdlg.h
@@ -9,8 +9,8 @@
 
 #include <optional>
 
-#include <ttstring_wx.h>     // ttString -- wxString with additional methods similar to ttlib::cstr
-#include "writesrc.h"  // CWriteSrcFiles -- Writes a new or update srcfiles.yaml file
+#include "writesrc.h"     // CWriteSrcFiles -- Writes a new or update srcfiles.yaml file
+#include <ttstring_wx.h>  // ttString -- wxString with additional methods similar to ttlib::cstr
 
 #include "optionsdlgBase.h"
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes problems with clang-format introduced by the switch to ttLib_wx. It also fixes the issues caused by an internal change in how CodeQL works.